### PR TITLE
Extra docs and TryFrom Instruction impls

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,11 @@
-// (C) Copyright 2019 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 
 use pest::iterators::Pair;
 use snafu::Snafu;
 
 use crate::parser::*;
 
+/// A Dockerfile parsing error.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 pub enum Error {
@@ -35,21 +36,22 @@ pub enum Error {
   UnknownParseError,
 
   #[snafu(display(
-    "unable to parse image reference '{}': {}", image, message
-  ))]
-  ImageParseError {
-    image: String,
-    message: String
-  },
-
-  #[snafu(display(
     "could not read Dockerfile: {}", source
   ))]
   ReadError {
     source: std::io::Error
+  },
+
+  #[snafu(display(
+    "could not convert instruction '{:?}' to desired type '{}'", from, to
+  ))]
+  ConversionError {
+    from: String,
+    to: String
   }
 }
 
+/// A Dockerfile parsing Result.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Helper to create an unexpected token error.

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,12 +1,30 @@
-// (C) Copyright 2019 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 
 use std::fmt;
 
 /// A parsed docker image reference
+///
+/// The `Display` impl may be used to convert a parsed image back to a plain
+/// string:
+/// ```
+/// use dockerfile_parser::ImageRef;
+///
+/// let image = ImageRef::parse("alpine:3.11");
+/// assert_eq!(image.registry, None);
+/// assert_eq!(image.image, "alpine");
+/// assert_eq!(image.tag, Some("3.11".to_string()));
+/// assert_eq!(format!("{}", image), "alpine:3.11");
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImageRef {
+  /// an optional registry, generally Docker Hub if unset
   pub registry: Option<String>,
+
+  /// an image string, possibly including a user or organization name
   pub image: String,
+
+  /// An optional image tag (after the colon, e.g. `:1.2.3`), generally inferred
+  /// to mean `:latest` if unset
   pub tag: Option<String>
 }
 
@@ -18,6 +36,10 @@ fn is_registry(token: &str) -> bool {
 }
 
 impl ImageRef {
+  /// Parses an `ImageRef` from a string.
+  ///
+  /// This is not fallible, however malformed image strings may return
+  /// unexpected results.
   pub fn parse(s: &str) -> ImageRef {
     // tags may be one of:
     // foo (implies registry.hub.docker.com/library/foo:latest)

--- a/src/instructions/cmd.rs
+++ b/src/instructions/cmd.rs
@@ -1,10 +1,18 @@
-// (C) Copyright 2019 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 
+use std::convert::TryFrom;
+
+use crate::dockerfile::Instruction;
 use crate::error::*;
 use crate::util::*;
 use crate::parser::*;
 
-
+/// A Dockerfile [`CMD` instruction][cmd].
+///
+/// An command may be defined as either a single string (to be run in the
+/// default shell), or a list of strings (to be run directly).
+///
+/// [cmd]: https://docs.docker.com/engine/reference/builder/#cmd
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum CmdInstruction {
   Shell(String),
@@ -69,5 +77,20 @@ mod tests {
     );
 
     Ok(())
+  }
+}
+
+impl<'a> TryFrom<&'a Instruction> for &'a CmdInstruction {
+  type Error = Error;
+
+  fn try_from(instruction: &'a Instruction) -> std::result::Result<Self, Self::Error> {
+    if let Instruction::Cmd(c) = instruction {
+      Ok(c)
+    } else {
+      Err(Error::ConversionError {
+        from: format!("{:?}", instruction),
+        to: "CmdInstruction".into()
+      })
+    }
   }
 }

--- a/src/instructions/entrypoint.rs
+++ b/src/instructions/entrypoint.rs
@@ -1,9 +1,18 @@
-// (C) Copyright 2019 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 
+use std::convert::TryFrom;
+
+use crate::dockerfile::Instruction;
 use crate::error::*;
 use crate::util::*;
 use crate::parser::*;
 
+/// A Dockerfile [`ENTRYPOINT` instruction][entrypoint].
+///
+/// An entrypoint may be defined as either a single string (to be run in the
+/// default shell), or a list of strings (to be run directly).
+///
+/// [entrypoint]: https://docs.docker.com/engine/reference/builder/#entrypoint
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum EntrypointInstruction {
   Shell(String),
@@ -30,6 +39,20 @@ impl EntrypointInstruction {
   }
 }
 
+impl TryFrom<Instruction> for EntrypointInstruction {
+  type Error = Error;
+
+  fn try_from(instruction: Instruction) -> std::result::Result<Self, Self::Error> {
+    if let Instruction::Entrypoint(e) = instruction {
+      Ok(e)
+    } else {
+      Err(Error::ConversionError {
+        from: format!("{:?}", instruction),
+        to: "EntrypointInstruction".into()
+      })
+    }
+  }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/instructions/env.rs
+++ b/src/instructions/env.rs
@@ -10,6 +10,7 @@ use crate::error::*;
 use enquote::unquote;
 use snafu::ResultExt;
 
+/// An environment variable key/value pair
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct EnvVar {
   pub key: String,

--- a/src/instructions/env.rs
+++ b/src/instructions/env.rs
@@ -1,5 +1,8 @@
-// (C) Copyright 2019 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 
+use std::convert::TryFrom;
+
+use crate::dockerfile::Instruction;
 use crate::parser::{Pair, Rule};
 use crate::util::*;
 use crate::error::*;
@@ -13,6 +16,9 @@ pub struct EnvVar {
   pub value: String
 }
 
+/// A Dockerfile [`ENV` instruction][env].
+///
+/// [env]: https://docs.docker.com/engine/reference/builder/#env
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct EnvInstruction(Vec<EnvVar>);
 
@@ -82,5 +88,20 @@ impl EnvInstruction {
     }
 
     Ok(EnvInstruction(vars))
+  }
+}
+
+impl<'a> TryFrom<&'a Instruction> for &'a EnvInstruction {
+  type Error = Error;
+
+  fn try_from(instruction: &'a Instruction) -> std::result::Result<Self, Self::Error> {
+    if let Instruction::Env(e) = instruction {
+      Ok(e)
+    } else {
+      Err(Error::ConversionError {
+        from: format!("{:?}", instruction),
+        to: "EnvInstruction".into()
+      })
+    }
   }
 }

--- a/src/instructions/misc.rs
+++ b/src/instructions/misc.rs
@@ -1,9 +1,19 @@
-// (C) Copyright 2019 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 
+use std::convert::TryFrom;
+
+use crate::dockerfile::Instruction;
 use crate::error::*;
 use crate::util::*;
 use crate::parser::*;
 
+/// A miscellaneous (unsupported) Dockerfile instruction.
+///
+/// These are instructions that aren't explicitly parsed. They may be invalid,
+/// deprecated, or otherwise unsupported by this library.
+///
+/// Unsupported but valid commands include: `MAINTAINER`, `EXPOSE`, `VOLUME`,
+/// `USER`, `WORKDIR`, `ONBUILD`, `STOPSIGNAL`, `HEALTHCHECK`, `SHELL`
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct MiscInstruction {
   instruction: String,
@@ -34,5 +44,20 @@ impl MiscInstruction {
     Ok(MiscInstruction {
       instruction, arguments
     })
+  }
+}
+
+impl<'a> TryFrom<&'a Instruction> for &'a MiscInstruction {
+  type Error = Error;
+
+  fn try_from(instruction: &'a Instruction) -> std::result::Result<Self, Self::Error> {
+    if let Instruction::Misc(m) = instruction {
+      Ok(m)
+    } else {
+      Err(Error::ConversionError {
+        from: format!("{:?}", instruction),
+        to: "MiscInstruction".into()
+      })
+    }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,34 @@
-// (C) Copyright 2019 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 
 #![forbid(unsafe_code)]
+
+//! # Rust parser for Dockerfile syntax
+//!
+//! A pure Rust library for parsing and inspecting Dockerfiles, useful for
+//! performing static analysis, writing linters, and creating automated tooling
+//! around Dockerfiles. It can provide useful syntax errors in addition to a
+//! full syntax tree.
+//!
+//! ## Quick start
+//!
+//! ```rust
+//! use dockerfile_parser::Dockerfile;
+//!
+//! let dockerfile = Dockerfile::parse(r#"
+//!   FROM alpine:3.11 as builder
+//!   RUN echo "hello world" > /hello-world
+//!
+//!   FROM scratch
+//!   COPY --from=builder /hello-world /hello-world
+//! "#).unwrap();
+//!
+//! for stage in dockerfile.iter_stages() {
+//!   println!("stage #{}", stage.index);
+//!   for ins in stage.instructions {
+//!     println!("  {:?}", ins);
+//!   }
+//! }
+//! ```
 
 #[macro_use] extern crate pest_derive;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,9 +1,11 @@
-// (C) Copyright 2019 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 
 use pest;
 
+/// The internal Pest parser.
 #[derive(Parser)]
 #[grammar = "dockerfile.pest"]
 pub(crate) struct DockerfileParser;
 
+/// A Pest Pair for Dockerfile rules.
 pub(crate) type Pair<'a> = pest::iterators::Pair<'a, Rule>;

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -1,4 +1,4 @@
-// (C) Copyright 2019 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 
 extern crate dockerfile_parser;
 


### PR DESCRIPTION
Adds a bunch of extra doc comments.

Noticed a need for a util to convert from an instruction enum to a
particular type for concise examples, so added `TryFrom<Instruction>`
impls for each instruction struct. Examples are now in the docs via
several new doctests.