### PR TITLE
Correctly parse images containing hash references

### DIFF
--- a/src/instructions/from.rs
+++ b/src/instructions/from.rs
@@ -101,7 +101,7 @@ mod tests {
       Rule::from,
       |p| FromInstruction::from_record(p, 0)
     )?;
-    
+
     assert_eq!(from, FromInstruction {
       span: Span { start: 0, end: 16 },
       index: 0,
@@ -110,7 +110,8 @@ mod tests {
       image_parsed: ImageRef {
         registry: None,
         image: "alpine".into(),
-        tag: Some("3.10".into())
+        tag: Some("3.10".into()),
+        hash: None
       },
       alias: None,
       alias_span: None

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -26,7 +26,8 @@ fn parse_basic() -> Result<(), dockerfile_parser::Error> {
       image_parsed: ImageRef {
         registry: None,
         image: "alpine".into(),
-        tag: Some("3.10".into())
+        tag: Some("3.10".into()),
+        hash: None
       },
       index: 0,
       alias: None,


### PR DESCRIPTION
This tweaks the image parser to properly handle docker image strings
containing hashes or digests, e.g. [1].

This is another minor breaking change for any downstream dependencies
that instantiate `ImageRef` directly in e.g. unit tests, as a new
field has been added to the struct.

[1] `hello-world@sha256:90659bf80b44ce6be8234e6ff90a1ac34acbeb826903b02cfa0da11c82cbc042`