### PR TITLE
Debug print enquote errors to avoid stack overflows

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ pub enum Error {
   },
 
   #[snafu(display(
-    "error unescaping string: {}", source
+    "error unescaping string: {:?}", source
   ))]
   UnescapeError {
     source: enquote::Error


### PR DESCRIPTION
`enquote::Error`'s `Display` implementation seems to recurse unintentionally, but the `Debug` impl is fine.

See also: https://github.com/reujab/enquote/issues/1