### PR TITLE
Add a function to resolve variables in ImageRefs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ pest = "2.1"
 pest_derive = "2.1"
 snafu = "0.6"
 enquote = "1.0"
+regex = "1.4"
+lazy_static = "1.4"
 
 [dev-dependencies]
 indoc = "0.3"

--- a/src/dockerfile_parser.rs
+++ b/src/dockerfile_parser.rs
@@ -162,7 +162,7 @@ fn parse_dockerfile(input: &str) -> Result<Dockerfile> {
         from_found = true;
       },
       Instruction::Arg(ref arg) => {
-        // args preceeding the first FROM instruction may be substituted into
+        // args preceding the first FROM instruction may be substituted into
         // all subsequent FROM image refs
         if !from_found {
           global_args.push(arg.clone());

--- a/src/image.rs
+++ b/src/image.rs
@@ -138,7 +138,8 @@ impl ImageRef {
   /// `ImageRef`.
   ///
   /// If this `ImageRef` contains any unknown variables or if any references are
-  /// recursive, returns None; otherwise, returns the fully-substituted string.
+  /// excessively recursive, returns None; otherwise, returns the
+  /// fully-substituted string.
   pub fn resolve_vars(&self, dockerfile: &Dockerfile) -> Option<ImageRef> {
     let vars: HashMap<&str, &str> = HashMap::from_iter(
       dockerfile.global_args

--- a/src/image.rs
+++ b/src/image.rs
@@ -133,6 +133,12 @@ impl ImageRef {
     }
   }
 
+  /// Given a Dockerfile (and its global `ARG`s), perform any necessary
+  /// variable substitution to resolve any variable references in this
+  /// `ImageRef`.
+  ///
+  /// If this `ImageRef` contains any unknown variables or if any references are
+  /// recursive, returns None; otherwise, returns the fully-substituted string.
   pub fn resolve_vars(&self, dockerfile: &Dockerfile) -> Option<ImageRef> {
     let vars: HashMap<&str, &str> = HashMap::from_iter(
       dockerfile.global_args

--- a/src/splicer.rs
+++ b/src/splicer.rs
@@ -139,6 +139,13 @@ impl Splicer {
     }
   }
 
+  pub(crate) fn from_str(s: &str) -> Splicer {
+    Splicer {
+      content: s.to_string(),
+      splice_offsets: Vec::new()
+    }
+  }
+
   /// Replaces a Span with the given replacement string, mutating the `content`
   /// string.
   ///


### PR DESCRIPTION
Variable substitutions in image references can now be resolved based
on a Dockerfile's global args, so long as they're specified within
the file.

Note that this adds dependencies for regex and lazy_static. These
could probably be made optional with feature gates on this new
function.