### PR TITLE
 Add `resolve_vars_with_context` to find variable names in an image

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -76,7 +76,7 @@ fn substitute<'a, 'b>(
     }
 
     let full_range = caps.get(0)?.range();
-    let var_name = caps.get(1).or(caps.get(2))?;
+    let var_name = caps.get(1).or_else(|| caps.get(2))?;
     let var_content = vars.get(var_name.as_str())?;
     let substituted_content = substitute(
       var_content,

--- a/src/instructions/label.rs
+++ b/src/instructions/label.rs
@@ -55,11 +55,11 @@ impl Label {
 
     let name = name.ok_or_else(|| Error::GenericParseError {
       message: "label name is required".into()
-    })?.to_string();
+    })?;
 
     let value = value.ok_or_else(|| Error::GenericParseError {
       message: "label value is required".into()
-    })?.to_string();
+    })?;
 
     Ok(Label::new(name, value))
   }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,5 @@
 // (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 
-use pest;
-
 /// The internal Pest parser.
 #[derive(Parser)]
 #[grammar = "dockerfile_parser.pest"]

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -81,6 +81,22 @@ impl<'a> PartialEq for Stage<'a> {
   }
 }
 
+impl<'a> Stage<'a> {
+  /// Finds the index, relative to this stage, of an ARG instruction defining
+  /// the given name. Per the Dockerfile spec, only instructions following the
+  /// ARG definition in a particular stage will have the value in scope, even
+  /// if it was a defined globally or in a previous stage.
+  pub fn arg_index(&self, name: &str) -> Option<usize> {
+    self.instructions
+      .iter()
+      .enumerate()
+      .find_map(|(i, ins)| match ins {
+        Instruction::Arg(a) => if &a.name == name { Some(i) } else { None },
+        _ => None
+      })
+  }
+}
+
 /// A collection of stages in a [multi-stage build].
 ///
 /// # Example

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -91,7 +91,7 @@ impl<'a> Stage<'a> {
       .iter()
       .enumerate()
       .find_map(|(i, ins)| match ins {
-        Instruction::Arg(a) => if &a.name == name { Some(i) } else { None },
+        Instruction::Arg(a) => if a.name == name { Some(i) } else { None },
         _ => None
       })
   }


### PR DESCRIPTION
Adds a new `ImageRef::resolve_vars_with_context()` to find all variable names that were used to build an image while resolving the end result.

Additionally adds a helper function, `Stage::arg_index()` that can be used to determine if a stage contains an `ARG` instruction with a particular name.

These two functions can be used together to determine if a particular `ARG` is used only to parameterize an image in a `FROM`, or if the content is actually used in some build stage.