### PR TITLE
Support singly-quoted strings

### DIFF
--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -124,10 +124,6 @@ env_pair_quoted_value = ${ string }
 env_pair_single_quoted_value = ${ single_quoted_string }
 env_pair = @{ env_pair_name ~ "=" ~ (env_pair_single_quoted_value | env_pair_quoted_value | env_pair_value) }
 env_pairs = { (arg_ws ~ env_pair)+ }
-//env_single_name = @{ ASCII_ALPHA+ }
-//env_single_value = @{ any_breakable }
-//env_single = { arg_ws ~ env_single_name ~ env_single_value }
-//env = _{ ^"env" ~ (env_pairs | env_single) }
 env = _{ ^"env" ~ env_pairs }
 
 misc_instruction = @{ ASCII_ALPHA+ }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -3,7 +3,7 @@
 // https://github.com/pest-parser/pest/blob/master/grammars/src/grammars/toml.pest
 
 dockerfile = { SOI ~ meta_step ~ (NEWLINE ~ meta_step)* ~ EOI }
-meta_step = _{ ws* ~ (step | comment)? ~ ws* } 
+meta_step = _{ ws* ~ (step | comment)? ~ ws* }
 
 step = _{
   (
@@ -32,8 +32,11 @@ step = _{
 comment = _{ "#" ~ (!NEWLINE ~ ANY)* }
 string  = @{ "\"" ~ inner ~ "\"" }
 inner   = @{ (!("\"" | "\\" | "\u{0000}" | "\u{001F}") ~ ANY)* ~ (escape ~ inner)? }
-escape  = @{ "\\" ~ ("b" | "t" | "n" | "f" | "r" | "\"" | "\\" | unicode | NEWLINE)? }
+escape  = @{ "\\" ~ ("b" | "t" | "n" | "f" | "r" | "\"" | "\\" | "'" | unicode | NEWLINE)? }
 unicode = @{ "u" ~ ASCII_HEX_DIGIT{4} | "U" ~ ASCII_HEX_DIGIT{8} }
+
+single_quoted_string = @{ "'" ~ single_quoted_inner ~ "'" }
+single_quoted_inner  = @{ (!("'" | "\\" | "\u{0000}" | "\u{001F}") ~ ANY)* ~ (escape ~ single_quoted_inner)? }
 
 // insignificant whitespace, not repeated
 ws = _{ " " | "\t" }
@@ -48,7 +51,7 @@ arg_ws_maybe = _{ (ws | ("\\" ~ NEWLINE))* }
 // escape (\)
 any_breakable = _{
   (
-    !NEWLINE ~ 
+    !NEWLINE ~
     !("\\" ~ NEWLINE) ~
     ANY
   )* ~ ("\\" ~ NEWLINE ~ any_breakable)?
@@ -85,7 +88,8 @@ from = { ^"from" ~ arg_ws ~ from_image ~ from_alias_outer?  }
 arg_name = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 arg_value = ${ any_whitespace }
 arg_quoted_value = ${ string }
-arg = { ^"arg" ~ arg_ws ~ arg_name ~ ("=" ~ (arg_quoted_value | arg_value))? }
+arg_single_quoted_value = ${ single_quoted_string }
+arg = { ^"arg" ~ arg_ws ~ arg_name ~ ("=" ~ (arg_single_quoted_value | arg_quoted_value | arg_value))? }
 
 label_name = ${ any_equals }
 label_quoted_name = ${ string }
@@ -117,12 +121,14 @@ copy = { ^"copy" ~ (arg_ws ~ copy_flag)* ~ (arg_ws ~ copy_pathspec){2,} }
 env_pair_name = ${ (ASCII_ALPHANUMERIC | "_")+ }
 env_pair_value = ${ any_whitespace }
 env_pair_quoted_value = ${ string }
-env_pair = @{ env_pair_name ~ "=" ~ (env_pair_quoted_value | env_pair_value) }
+env_pair_single_quoted_value = ${ single_quoted_string }
+env_pair = @{ env_pair_name ~ "=" ~ (env_pair_single_quoted_value | env_pair_quoted_value | env_pair_value) }
 env_pairs = { (arg_ws ~ env_pair)+ }
-env_single_name = @{ ASCII_ALPHA+ }
-env_single_value = @{ any_breakable }
-env_single = {  arg_ws ~ env_single_name ~ env_single_value }
-env = _{ ^"env" ~ (env_pairs | env_single) }
+//env_single_name = @{ ASCII_ALPHA+ }
+//env_single_value = @{ any_breakable }
+//env_single = { arg_ws ~ env_single_name ~ env_single_value }
+//env = _{ ^"env" ~ (env_pairs | env_single) }
+env = _{ ^"env" ~ env_pairs }
 
 misc_instruction = @{ ASCII_ALPHA+ }
 misc_arguments = @{ any_breakable }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -30,13 +30,15 @@ step = _{
 }
 
 comment = _{ "#" ~ (!NEWLINE ~ ANY)* }
-string  = @{ "\"" ~ inner ~ "\"" }
+double_quoted_string  = @{ "\"" ~ inner ~ "\"" }
 inner   = @{ (!("\"" | "\\" | "\u{0000}" | "\u{001F}") ~ ANY)* ~ (escape ~ inner)? }
 escape  = @{ "\\" ~ ("b" | "t" | "n" | "f" | "r" | "\"" | "\\" | "'" | unicode | NEWLINE)? }
 unicode = @{ "u" ~ ASCII_HEX_DIGIT{4} | "U" ~ ASCII_HEX_DIGIT{8} }
 
 single_quoted_string = @{ "'" ~ single_quoted_inner ~ "'" }
 single_quoted_inner  = @{ (!("'" | "\\" | "\u{0000}" | "\u{001F}") ~ ANY)* ~ (escape ~ single_quoted_inner)? }
+
+string = ${ single_quoted_string | double_quoted_string }
 
 // insignificant whitespace, not repeated
 ws = _{ " " | "\t" }
@@ -88,8 +90,7 @@ from = { ^"from" ~ arg_ws ~ from_image ~ from_alias_outer?  }
 arg_name = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 arg_value = ${ any_whitespace }
 arg_quoted_value = ${ string }
-arg_single_quoted_value = ${ single_quoted_string }
-arg = { ^"arg" ~ arg_ws ~ arg_name ~ ("=" ~ (arg_single_quoted_value | arg_quoted_value | arg_value))? }
+arg = { ^"arg" ~ arg_ws ~ arg_name ~ ("=" ~ (arg_quoted_value | arg_value))? }
 
 label_name = ${ any_equals }
 label_quoted_name = ${ string }
@@ -121,8 +122,7 @@ copy = { ^"copy" ~ (arg_ws ~ copy_flag)* ~ (arg_ws ~ copy_pathspec){2,} }
 env_pair_name = ${ (ASCII_ALPHANUMERIC | "_")+ }
 env_pair_value = ${ any_whitespace }
 env_pair_quoted_value = ${ string }
-env_pair_single_quoted_value = ${ single_quoted_string }
-env_pair = @{ env_pair_name ~ "=" ~ (env_pair_single_quoted_value | env_pair_quoted_value | env_pair_value) }
+env_pair = @{ env_pair_name ~ "=" ~ (env_pair_quoted_value | env_pair_value) }
 env_pairs = { (arg_ws ~ env_pair)+ }
 env = _{ ^"env" ~ env_pairs }
 

--- a/src/dockerfile_parser.rs
+++ b/src/dockerfile_parser.rs
@@ -89,7 +89,6 @@ impl TryFrom<Pair<'_>> for Instruction {
 
       Rule::copy => Instruction::Copy(CopyInstruction::from_record(record)?),
 
-      Rule::env_single => EnvInstruction::from_single_record(record)?.into(),
       Rule::env_pairs => EnvInstruction::from_pairs_record(record)?.into(),
 
       Rule::misc => MiscInstruction::from_record(record)?.into(),

--- a/src/instructions/arg.rs
+++ b/src/instructions/arg.rs
@@ -46,7 +46,12 @@ impl ArgInstruction {
           let v = unquote(field.as_str()).context(UnescapeError)?;
 
           value = Some((v, Span::from_pair(&field)));
-        }
+        },
+        Rule::arg_single_quoted_value => {
+          let v = unquote(field.as_str()).context(UnescapeError)?;
+
+          value = Some((v, Span::from_pair(&field)));
+        },
         Rule::arg_value => value = Some((
           field.as_str().to_string(),
           Span::from_pair(&field)
@@ -90,4 +95,52 @@ impl<'a> TryFrom<&'a Instruction> for &'a ArgInstruction {
      })
    }
  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::Dockerfile;
+  use crate::test_util::*;
+
+  #[test]
+  fn arg_strings() -> Result<()> {
+    assert_eq!(
+      parse_single(r#"arg foo=bar"#, Rule::arg)?,
+      ArgInstruction {
+        span: Span::new(0, 11),
+        name: "foo".into(),
+        name_span: Span::new(4, 7),
+        value: Some("bar".into()),
+        value_span: Some(Span::new(8, 11)),
+      }.into()
+    );
+
+    assert_eq!(
+      parse_single(r#"arg foo="bar""#, Rule::arg)?,
+      ArgInstruction {
+        span: Span::new(0, 13),
+        name: "foo".into(),
+        name_span: Span::new(4, 7),
+        value: Some("bar".into()),
+        value_span: Some(Span::new(8, 13)),
+      }.into()
+    );
+
+    assert_eq!(
+      parse_single(r#"arg foo='bar'"#, Rule::arg)?,
+      ArgInstruction {
+        span: Span::new(0, 13),
+        name: "foo".into(),
+        name_span: Span::new(4, 7),
+        value: Some("bar".into()),
+        value_span: Some(Span::new(8, 13)),
+      }.into()
+    );
+
+    assert!(Dockerfile::parse(r#"arg foo="bar"bar"#).is_err());
+    assert!(Dockerfile::parse(r#"arg foo='bar'bar"#).is_err());
+
+    Ok(())
+  }
 }

--- a/src/instructions/arg.rs
+++ b/src/instructions/arg.rs
@@ -47,11 +47,6 @@ impl ArgInstruction {
 
           value = Some((v, Span::from_pair(&field)));
         },
-        Rule::arg_single_quoted_value => {
-          let v = unquote(field.as_str()).context(UnescapeError)?;
-
-          value = Some((v, Span::from_pair(&field)));
-        },
         Rule::arg_value => value = Some((
           field.as_str().to_string(),
           Span::from_pair(&field)

--- a/src/instructions/env.rs
+++ b/src/instructions/env.rs
@@ -49,11 +49,6 @@ fn parse_env_pair(record: Pair) -> Result<EnvVar> {
 
         value = Some(v)
       },
-      Rule::env_pair_single_quoted_value => {
-        let v = unquote(field.as_str()).context(UnescapeError)?;
-
-        value = Some(v)
-      },
       _ => return Err(unexpected_token(field))
     }
   }


### PR DESCRIPTION
This tweaks the grammar to allow single-quoted strings in all places that double-quoted strings have been allowed previously.

Also, removes `env_single` since it was parsing as `env_pairs` anyway, which is a superset of single.