### PR TITLE
Allow comments in multiline blocks

### DIFF
--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -138,14 +138,14 @@ copy_flag = { "--" ~ copy_flag_name ~ "=" ~ copy_flag_value }
 copy_pathspec = @{ any_whitespace }
 copy = { ^"copy" ~ (arg_ws ~ copy_flag)* ~ (arg_ws ~ copy_pathspec){2,} }
 
-env_pair_name = ${ (ASCII_ALPHANUMERIC | "_")+ }
+env_name = ${ (ASCII_ALPHANUMERIC | "_")+ }
 env_pair_value = ${ any_whitespace }
 env_pair_quoted_value = ${ string }
-env_pair = @{ env_pair_name ~ "=" ~ (env_pair_quoted_value | env_pair_value) }
+env_pair = @{ env_name ~ "=" ~ (env_pair_quoted_value | env_pair_value) }
 env_pairs = { (arg_ws ~ env_pair?)+ }
-env_single_name = @{ ASCII_ALPHA+ }
+env_single_quoted_value = ${ string }
 env_single_value = @{ any_breakable }
-env_single = {  arg_ws ~ env_single_name ~ arg_ws ~ env_single_value }
+env_single = {  arg_ws ~ env_name ~ arg_ws ~ (env_single_quoted_value | env_single_value) }
 env = _{ ^"env" ~ (env_single | env_pairs) }
 
 misc_instruction = @{ ASCII_ALPHA+ }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -29,7 +29,13 @@ step = _{
   )
 }
 
+// insignificant whitespace, not repeated
+ws = _{ " " | "\t" }
+
 comment = @{ "#" ~ (!NEWLINE ~ ANY)* }
+comment_line = _{ ws* ~ comment ~ NEWLINE? }
+empty_line = _{ ws* ~ NEWLINE }
+
 double_quoted_string  = @{ "\"" ~ inner ~ "\"" }
 inner   = @{ (!("\"" | "\\" | "\u{0000}" | "\u{001F}") ~ ANY)* ~ (escape ~ inner)? }
 escape  = @{ "\\" ~ ("b" | "t" | "n" | "f" | "r" | "\"" | "\\" | "'" | unicode | NEWLINE)? }
@@ -40,24 +46,20 @@ single_quoted_inner  = @{ (!("'" | "\\" | "\u{0000}" | "\u{001F}") ~ ANY)* ~ (es
 
 string = ${ single_quoted_string | double_quoted_string }
 
-// insignificant whitespace, not repeated
-ws = _{ " " | "\t" }
-
 // a line continuation, allowing an instruction to continue onto a new line
 line_continuation = _{ "\\" ~ ws* ~ NEWLINE }
 
 // whitespace that may appear between instruction arguments
 // this allows instructions to expand past a newline if escaped
-arg_ws = _{ (ws | line_continuation)+ }
+arg_ws = _{ (ws | line_continuation ~ (comment_line | empty_line)*)+ }
 
 // like arg_ws, but where whitespace is optional
-arg_ws_maybe = _{ (ws | line_continuation)* }
+arg_ws_maybe = _{ (ws | line_continuation ~ (comment_line | empty_line)*)* }
 
 // continues consuming input beyond a newline, if the newline is preceeded by an
 // escape (\)
 // these tokens need to be preserved in the final tree so they can be handled
 // appropraitely; pest's ignore rules aren't sufficient for our needs
-comment_line = _{ ws* ~ comment ~ NEWLINE? }
 any_content = @{
   (
     !NEWLINE ~
@@ -116,7 +118,7 @@ label_quoted_value = ${ string }
 label_pair = {
   (label_quoted_name | label_name) ~ "=" ~ (label_quoted_value | label_value)
 }
-label = { ^"label" ~ (arg_ws ~ label_pair)+ }
+label = { ^"label" ~ (arg_ws ~ label_pair?)+ }
 
 run_shell = @{ any_breakable }
 run_exec = { string_array }
@@ -140,7 +142,7 @@ env_pair_name = ${ (ASCII_ALPHANUMERIC | "_")+ }
 env_pair_value = ${ any_whitespace }
 env_pair_quoted_value = ${ string }
 env_pair = @{ env_pair_name ~ "=" ~ (env_pair_quoted_value | env_pair_value) }
-env_pairs = { (arg_ws ~ env_pair)+ }
+env_pairs = { (arg_ws ~ env_pair?)+ }
 env_single_name = @{ ASCII_ALPHA+ }
 env_single_value = @{ any_breakable }
 env_single = {  arg_ws ~ env_single_name ~ arg_ws ~ env_single_value }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -118,7 +118,10 @@ label_quoted_value = ${ string }
 label_pair = {
   (label_quoted_name | label_name) ~ "=" ~ (label_quoted_value | label_value)
 }
-label = { ^"label" ~ (arg_ws ~ label_pair?)+ }
+label_single_name = { any_equals }
+label_single_quoted_name = { string }
+label_single = { arg_ws ~ (label_single_quoted_name | label_single_name) ~ arg_ws ~ (label_quoted_value | label_value) }
+label = { ^"label" ~ (label_single | (arg_ws ~ label_pair?)+) }
 
 run_shell = @{ any_breakable }
 run_exec = { string_array }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -3,7 +3,7 @@
 // https://github.com/pest-parser/pest/blob/master/grammars/src/grammars/toml.pest
 
 dockerfile = { SOI ~ meta_step ~ (NEWLINE ~ meta_step)* ~ EOI }
-meta_step = _{ ws* ~ (step | comment)? ~ ws* } 
+meta_step = _{ ws* ~ (step | comment)? ~ ws* }
 
 step = _{
   (
@@ -46,12 +46,15 @@ arg_ws_maybe = _{ (ws | ("\\" ~ NEWLINE))* }
 
 // continues consuming input beyond a newline, if the newline is preceeded by an
 // escape (\)
+// TODO: this does undesirable things with comments in RUN, is that avoidable?
+// seems like if we're going to pass comments through we should at least include
+// the newlines
 any_breakable = _{
   (
-    !NEWLINE ~ 
+    !NEWLINE ~
     !("\\" ~ NEWLINE) ~
     ANY
-  )* ~ ("\\" ~ NEWLINE ~ any_breakable)?
+  )* ~ ("\\" ~ NEWLINE ~ (ws* ~ comment ~ NEWLINE)? ~ any_breakable)?
 }
 
 // consumes any character until the end of the line

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -44,7 +44,7 @@ string = ${ single_quoted_string | double_quoted_string }
 ws = _{ " " | "\t" }
 
 // a line continuation, allowing an instruction to continue onto a new line
-line_continuation = _{ "\\" ~ NEWLINE }
+line_continuation = _{ "\\" ~ ws* ~ NEWLINE }
 
 // whitespace that may appear between instruction arguments
 // this allows instructions to expand past a newline if escaped

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -29,7 +29,7 @@ step = _{
   )
 }
 
-comment = _{ "#" ~ (!NEWLINE ~ ANY)* }
+comment = @{ "#" ~ (!NEWLINE ~ ANY)* }
 double_quoted_string  = @{ "\"" ~ inner ~ "\"" }
 inner   = @{ (!("\"" | "\\" | "\u{0000}" | "\u{001F}") ~ ANY)* ~ (escape ~ inner)? }
 escape  = @{ "\\" ~ ("b" | "t" | "n" | "f" | "r" | "\"" | "\\" | "'" | unicode | NEWLINE)? }
@@ -43,23 +43,37 @@ string = ${ single_quoted_string | double_quoted_string }
 // insignificant whitespace, not repeated
 ws = _{ " " | "\t" }
 
+// a line continuation, allowing an instruction to continue onto a new line
+line_continuation = _{ "\\" ~ NEWLINE }
+
 // whitespace that may appear between instruction arguments
 // this allows instructions to expand past a newline if escaped
-arg_ws = _{ (ws | ("\\" ~ NEWLINE))+ }
+arg_ws = _{ (ws | line_continuation)+ }
 
-arg_ws_maybe = _{ (ws | ("\\" ~ NEWLINE))* }
+// like arg_ws, but where whitespace is optional
+arg_ws_maybe = _{ (ws | line_continuation)* }
 
 // continues consuming input beyond a newline, if the newline is preceeded by an
 // escape (\)
-// TODO: this does undesirable things with comments in RUN, is that avoidable?
-// seems like if we're going to pass comments through we should at least include
-// the newlines
-any_breakable = _{
+// these tokens need to be preserved in the final tree so they can be handled
+// appropraitely; pest's ignore rules aren't sufficient for our needs
+comment_line = _{ ws* ~ comment ~ NEWLINE? }
+any_content = @{
   (
     !NEWLINE ~
-    !("\\" ~ NEWLINE) ~
+    !line_continuation ~
     ANY
-  )* ~ ("\\" ~ NEWLINE ~ (ws* ~ comment ~ NEWLINE)* ~ any_breakable)?
+  )+
+}
+any_breakable = ${
+  (
+    // can be any comment string (no line continuation required)
+    comment_line ~ any_breakable?
+  ) | (
+    // ... OR some piece of content, requiring a continuation EXCEPT on the
+    // final line
+    any_content ~ (line_continuation ~ any_breakable)?
+  )
 }
 
 // consumes any character until the end of the line
@@ -127,7 +141,10 @@ env_pair_value = ${ any_whitespace }
 env_pair_quoted_value = ${ string }
 env_pair = @{ env_pair_name ~ "=" ~ (env_pair_quoted_value | env_pair_value) }
 env_pairs = { (arg_ws ~ env_pair)+ }
-env = _{ ^"env" ~ env_pairs }
+env_single_name = @{ ASCII_ALPHA+ }
+env_single_value = @{ any_breakable }
+env_single = {  arg_ws ~ env_single_name ~ arg_ws ~ env_single_value }
+env = _{ ^"env" ~ (env_single | env_pairs) }
 
 misc_instruction = @{ ASCII_ALPHA+ }
 misc_arguments = @{ any_breakable }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -54,7 +54,7 @@ any_breakable = _{
     !NEWLINE ~
     !("\\" ~ NEWLINE) ~
     ANY
-  )* ~ ("\\" ~ NEWLINE ~ (ws* ~ comment ~ NEWLINE)? ~ any_breakable)?
+  )* ~ ("\\" ~ NEWLINE ~ (ws* ~ comment ~ NEWLINE)* ~ any_breakable)?
 }
 
 // consumes any character until the end of the line

--- a/src/dockerfile_parser.rs
+++ b/src/dockerfile_parser.rs
@@ -45,6 +45,170 @@ pub enum Instruction {
   Misc(MiscInstruction)
 }
 
+impl Instruction {
+  /// Attempts to convert this instruction into a FromInstruction, returning
+  /// None if impossible.
+  pub fn into_from(self) -> Option<FromInstruction> {
+    match self {
+      Instruction::From(f) => Some(f),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into a FromInstruction, returning
+  /// None if impossible.
+  pub fn as_from(&self) -> Option<&FromInstruction> {
+    match self {
+      Instruction::From(f) => Some(f),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into an ArgInstruction, returning
+  /// None if impossible.
+  pub fn into_arg(self) -> Option<ArgInstruction> {
+    match self {
+      Instruction::Arg(a) => Some(a),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into an ArgInstruction, returning
+  /// None if impossible.
+  pub fn as_arg(&self) -> Option<&ArgInstruction> {
+    match self {
+      Instruction::Arg(a) => Some(a),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into a LabelInstruction, returning
+  /// None if impossible.
+  pub fn into_label(self) -> Option<LabelInstruction> {
+    match self {
+      Instruction::Label(l) => Some(l),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into a LabelInstruction, returning
+  /// None if impossible.
+  pub fn as_label(&self) -> Option<&LabelInstruction> {
+    match self {
+      Instruction::Label(l) => Some(l),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into a RunInstruction, returning
+  /// None if impossible.
+  pub fn into_run(self) -> Option<RunInstruction> {
+    match self {
+      Instruction::Run(r) => Some(r),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into a RunInstruction, returning
+  /// None if impossible.
+  pub fn as_run(&self) -> Option<&RunInstruction> {
+    match self {
+      Instruction::Run(r) => Some(r),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into an EntrypointInstruction,
+  /// returning None if impossible.
+  pub fn into_entrypoint(self) -> Option<EntrypointInstruction> {
+    match self {
+      Instruction::Entrypoint(e) => Some(e),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into an EntrypointInstruction,
+  /// returning None if impossible.
+  pub fn as_entrypoint(&self) -> Option<&EntrypointInstruction> {
+    match self {
+      Instruction::Entrypoint(e) => Some(e),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into a CmdInstruction, returning
+  /// None if impossible.
+  pub fn into_cmd(self) -> Option<CmdInstruction> {
+    match self {
+      Instruction::Cmd(c) => Some(c),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into a CmdInstruction, returning
+  /// None if impossible.
+  pub fn as_cmd(&self) -> Option<&CmdInstruction> {
+    match self {
+      Instruction::Cmd(c) => Some(c),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into a CopyInstruction, returning
+  /// None if impossible.
+  pub fn into_copy(self) -> Option<CopyInstruction> {
+    match self {
+      Instruction::Copy(c) => Some(c),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into a CopyInstruction, returning
+  /// None if impossible.
+  pub fn as_copy(&self) -> Option<&CopyInstruction> {
+    match self {
+      Instruction::Copy(c) => Some(c),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into an EnvInstruction, returning
+  /// None if impossible.
+  pub fn into_env(self) -> Option<EnvInstruction> {
+    match self {
+      Instruction::Env(e) => Some(e),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into an EnvInstruction, returning
+  /// None if impossible.
+  pub fn as_env(&self) -> Option<&EnvInstruction> {
+    match self {
+      Instruction::Env(e) => Some(e),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into a MiscInstruction, returning
+  /// None if impossible.
+  pub fn into_misc(self) -> Option<MiscInstruction> {
+    match self {
+      Instruction::Misc(m) => Some(m),
+      _ => None,
+    }
+  }
+
+  /// Attempts to convert this instruction into a MiscInstruction, returning
+  /// None if impossible.
+  pub fn as_misc(&self) -> Option<&MiscInstruction> {
+    match self {
+      Instruction::Misc(m) => Some(m),
+      _ => None,
+    }
+  }
+}
+
 /// Maps an instruction struct to its enum variant, implementing From<T> on
 /// Instruction for it.
 macro_rules! impl_from_instruction {
@@ -89,9 +253,13 @@ impl TryFrom<Pair<'_>> for Instruction {
 
       Rule::copy => Instruction::Copy(CopyInstruction::from_record(record)?),
 
+      Rule::env_single => EnvInstruction::from_single_record(record)?.into(),
       Rule::env_pairs => EnvInstruction::from_pairs_record(record)?.into(),
 
       Rule::misc => MiscInstruction::from_record(record)?.into(),
+
+      // TODO: consider exposing comments
+      // Rule::comment => ...,
       _ => return Err(unexpected_token(record))
     };
 
@@ -149,6 +317,11 @@ fn parse_dockerfile(input: &str) -> Result<Dockerfile> {
 
   for record in dockerfile.into_inner() {
     if let Rule::EOI = record.as_rule() {
+      continue;
+    }
+
+    // TODO: consider exposing comments in the parse result
+    if let Rule::comment = record.as_rule() {
       continue;
     }
 

--- a/src/instructions/arg.rs
+++ b/src/instructions/arg.rs
@@ -51,6 +51,7 @@ impl ArgInstruction {
           field.as_str().to_string(),
           Span::from_pair(&field)
         )),
+        Rule::comment => continue,
         _ => return Err(unexpected_token(field))
       }
     }

--- a/src/instructions/cmd.rs
+++ b/src/instructions/cmd.rs
@@ -15,7 +15,7 @@ use crate::parser::*;
 /// [cmd]: https://docs.docker.com/engine/reference/builder/#cmd
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum CmdInstruction {
-  Shell(String),
+  Shell(BreakableString),
   Exec(Vec<String>)
 }
 
@@ -25,58 +25,51 @@ impl CmdInstruction {
   }
 
   pub(crate) fn from_shell_record(record: Pair) -> Result<CmdInstruction> {
-    Ok(CmdInstruction::Shell(
-      clean_escaped_breaks(record.as_str())
-    ))
-  }
-
-  pub fn shell<S: Into<String>>(s: S) -> CmdInstruction {
-    CmdInstruction::Shell(s.into())
+    Ok(CmdInstruction::Shell(parse_any_breakable(record)?))
   }
 
   pub fn exec<S: Into<String>>(args: Vec<S>) -> CmdInstruction {
     CmdInstruction::Exec(args.into_iter().map(|s| s.into()).collect())
   }
-}
 
-#[cfg(test)]
-mod tests {
-  use super::*;
-  use crate::test_util::*;
-
-  #[test]
-  fn cmd_basic() -> Result<()> {
-    assert_eq!(
-      parse_single(r#"cmd echo "hello world""#, Rule::cmd)?,
-      CmdInstruction::shell("echo \"hello world\"").into()
-    );
-
-    assert_eq!(
-      parse_single(r#"cmd ["echo", "hello world"]"#, Rule::cmd)?,
-      CmdInstruction::exec(vec!["echo", "hello world"]).into()
-    );
-
-    Ok(())
+  /// Unpacks this instruction into its inner value if it is a Shell-form
+  /// instruction, otherwise returns None.
+  pub fn into_shell(self) -> Option<BreakableString> {
+    if let CmdInstruction::Shell(s) = self {
+      Some(s)
+    } else {
+      None
+    }
   }
 
-  #[test]
-  fn cmd_multiline() -> Result<()> {
-    assert_eq!(
-      parse_single(r#"cmd echo \
-        "hello world""#, Rule::cmd)?,
-      CmdInstruction::shell("echo         \"hello world\"").into()
-    );
+  /// Unpacks this instruction into its inner value if it is a Shell-form
+  /// instruction, otherwise returns None.
+  pub fn as_shell(&self) -> Option<&BreakableString> {
+    if let CmdInstruction::Shell(s) = self {
+      Some(s)
+    } else {
+      None
+    }
+  }
 
-    assert_eq!(
-      parse_single(r#"cmd\
-        [\
-        "echo", \
-        "hello world"\
-        ]"#, Rule::cmd)?,
-      CmdInstruction::exec(vec!["echo", "hello world"]).into()
-    );
+  /// Unpacks this instruction into its inner value if it is an Exec-form
+  /// instruction, otherwise returns None.
+  pub fn into_exec(self) -> Option<Vec<String>> {
+    if let CmdInstruction::Exec(s) = self {
+      Some(s)
+    } else {
+      None
+    }
+  }
 
-    Ok(())
+  /// Unpacks this instruction into its inner value if it is an Exec-form
+  /// instruction, otherwise returns None.
+  pub fn as_exec(&self) -> Option<&Vec<String>> {
+    if let CmdInstruction::Exec(s) = self {
+      Some(s)
+    } else {
+      None
+    }
   }
 }
 
@@ -92,5 +85,127 @@ impl<'a> TryFrom<&'a Instruction> for &'a CmdInstruction {
         to: "CmdInstruction".into()
       })
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use indoc::indoc;
+
+  use super::*;
+  use crate::test_util::*;
+
+  #[test]
+  fn cmd_basic() -> Result<()> {
+    assert_eq!(
+      parse_single(r#"CMD echo "hello world""#, Rule::cmd)?
+        .as_cmd().unwrap()
+        .as_shell().unwrap(),
+      &BreakableString::new((4, 22))
+        .add_string((4, 22), "echo \"hello world\"")
+    );
+
+    assert_eq!(
+      parse_single(r#"CMD echo "hello world""#, Rule::cmd)?
+        .as_cmd().unwrap()
+        .as_shell().unwrap()
+        .to_string(),
+      "echo \"hello world\""
+    );
+
+    assert_eq!(
+      parse_single(r#"cmd ["echo", "hello world"]"#, Rule::cmd)?,
+      CmdInstruction::exec(vec!["echo", "hello world"]).into()
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn cmd_multiline_exec() -> Result<()> {
+    assert_eq!(
+      parse_single(r#"cmd\
+        [\
+        "echo", \
+        "hello world"\
+        ]"#, Rule::cmd)?,
+      CmdInstruction::exec(vec!["echo", "hello world"]).into()
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn cmd_multiline_shell() -> Result<()> {
+    assert_eq!(
+      parse_single(indoc!(r#"
+        cmd echo \
+          "hello world"
+      "#), Rule::cmd)?
+        .as_cmd().unwrap()
+        .as_shell().unwrap(),
+      &BreakableString::new((4, 26))
+        .add_string((4, 9), "echo ")
+        .add_string((11, 26), "  \"hello world\"")
+    );
+
+    assert_eq!(
+      parse_single(indoc!(r#"
+        cmd echo \
+          "hello world"
+      "#), Rule::cmd)?
+        .as_cmd().unwrap()
+        .as_shell().unwrap()
+        .to_string(),
+      "echo   \"hello world\""
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn cmd_multiline_shell_large() -> Result<()> {
+    // note: the trailing `\` at the end is _almost_ nonsense and generates a
+    // warning from docker
+    let ins = parse_single(
+      indoc!(r#"
+        cmd set -x && \
+            # lorem ipsum
+            echo "hello world" && \
+            # dolor sit amet,
+            # consectetur \
+            # adipiscing elit, \
+            # sed do eiusmod
+            # tempor incididunt ut labore
+            echo foo && \
+            echo 'bar' \
+            && echo baz \
+            # et dolore magna aliqua."#),
+      Rule::cmd
+    )?.into_cmd().unwrap().into_shell().unwrap();
+
+    assert_eq!(
+      ins,
+      BreakableString::new((4, 266))
+        .add_string((4, 14), "set -x && ")
+        .add_comment((20, 33), "# lorem ipsum")
+        .add_string((34, 60), "    echo \"hello world\" && ")
+        .add_comment((66, 83), "# dolor sit amet,")
+        .add_comment((88, 103), "# consectetur \\")
+        .add_comment((108, 128), "# adipiscing elit, \\")
+        .add_comment((133, 149), "# sed do eiusmod")
+        .add_comment((154, 183), "# tempor incididunt ut labore")
+        .add_string((184, 200), "    echo foo && ")
+        .add_string((202, 217), "    echo 'bar' ")
+        .add_string((219, 235), "    && echo baz ")
+        .add_comment((241, 266), "# et dolore magna aliqua.")
+    );
+
+    assert_eq!(
+      ins.to_string(),
+      r#"set -x &&     echo "hello world" &&     echo foo &&     echo 'bar'     && echo baz "#
+    );
+
+    Ok(())
   }
 }

--- a/src/instructions/entrypoint.rs
+++ b/src/instructions/entrypoint.rs
@@ -15,7 +15,7 @@ use crate::parser::*;
 /// [entrypoint]: https://docs.docker.com/engine/reference/builder/#entrypoint
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum EntrypointInstruction {
-  Shell(String),
+  Shell(BreakableString),
   Exec(Vec<String>)
 }
 
@@ -25,17 +25,51 @@ impl EntrypointInstruction {
   }
 
   pub(crate) fn from_shell_record(record: Pair) -> Result<EntrypointInstruction> {
-    Ok(EntrypointInstruction::Shell(
-      clean_escaped_breaks(record.as_str())
-    ))
-  }
-
-  pub fn shell<S: Into<String>>(s: S) -> EntrypointInstruction {
-    EntrypointInstruction::Shell(s.into())
+    Ok(EntrypointInstruction::Shell(parse_any_breakable(record)?))
   }
 
   pub fn exec<S: Into<String>>(args: Vec<S>) -> EntrypointInstruction {
     EntrypointInstruction::Exec(args.into_iter().map(|s| s.into()).collect())
+  }
+
+  /// Unpacks this instruction into its inner value if it is a Shell-form
+  /// instruction, otherwise returns None.
+  pub fn into_shell(self) -> Option<BreakableString> {
+    if let EntrypointInstruction::Shell(s) = self {
+      Some(s)
+    } else {
+      None
+    }
+  }
+
+  /// Unpacks this instruction into its inner value if it is a Shell-form
+  /// instruction, otherwise returns None.
+  pub fn as_shell(&self) -> Option<&BreakableString> {
+    if let EntrypointInstruction::Shell(s) = self {
+      Some(s)
+    } else {
+      None
+    }
+  }
+
+  /// Unpacks this instruction into its inner value if it is an Exec-form
+  /// instruction, otherwise returns None.
+  pub fn into_exec(self) -> Option<Vec<String>> {
+    if let EntrypointInstruction::Exec(s) = self {
+      Some(s)
+    } else {
+      None
+    }
+  }
+
+  /// Unpacks this instruction into its inner value if it is an Exec-form
+  /// instruction, otherwise returns None.
+  pub fn as_exec(&self) -> Option<&Vec<String>> {
+    if let EntrypointInstruction::Exec(s) = self {
+      Some(s)
+    } else {
+      None
+    }
   }
 }
 
@@ -56,14 +90,19 @@ impl TryFrom<Instruction> for EntrypointInstruction {
 
 #[cfg(test)]
 mod tests {
+  use indoc::indoc;
+
   use super::*;
   use crate::test_util::*;
 
   #[test]
   fn entrypoint_basic() -> Result<()> {
     assert_eq!(
-      parse_single(r#"entrypoint echo "hello world""#, Rule::entrypoint)?,
-      EntrypointInstruction::shell("echo \"hello world\"").into()
+      parse_single(r#"entrypoint echo "hello world""#, Rule::entrypoint)?
+        .as_entrypoint().unwrap()
+        .as_shell().unwrap(),
+      &BreakableString::new((11, 29))
+        .add_string((11, 29), "echo \"hello world\"")
     );
 
     assert_eq!(
@@ -75,13 +114,7 @@ mod tests {
   }
 
   #[test]
-  fn entrypoint_multiline() -> Result<()> {
-    assert_eq!(
-      parse_single(r#"entrypoint echo \
-        "hello world""#, Rule::entrypoint)?,
-      EntrypointInstruction::shell("echo         \"hello world\"").into()
-    );
-
+  fn entrypoint_multiline_exec() -> Result<()> {
     assert_eq!(
       parse_single(r#"entrypoint\
         [\
@@ -89,6 +122,69 @@ mod tests {
         "hello world"\
         ]"#, Rule::entrypoint)?,
       EntrypointInstruction::exec(vec!["echo", "hello world"]).into()
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn entrypoint_multiline_shell() -> Result<()> {
+    assert_eq!(
+      parse_single(indoc!(r#"
+        entrypoint echo \
+          "hello world"
+      "#), Rule::entrypoint)?
+        .as_entrypoint().unwrap()
+        .as_shell().unwrap(),
+      &BreakableString::new((11, 33))
+        .add_string((11, 16), "echo ")
+        .add_string((18, 33), "  \"hello world\"")
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn entrypoint_multiline_large() -> Result<()> {
+    // note: the trailing `\` at the end is _almost_ nonsense and generates a
+    // warning from docker
+    let ins = parse_single(
+      indoc!(r#"
+        entrypoint set -x && \
+            # lorem ipsum
+            echo "hello world" && \
+            # dolor sit amet,
+            # consectetur \
+            # adipiscing elit, \
+            # sed do eiusmod
+            # tempor incididunt ut labore
+            echo foo && \
+            echo 'bar' \
+            && echo baz \
+            # et dolore magna aliqua."#),
+      Rule::entrypoint
+    )?.into_entrypoint().unwrap().into_shell().unwrap();
+
+    assert_eq!(
+      ins,
+      BreakableString::new((11, 273))
+        .add_string((11, 21), "set -x && ")
+        .add_comment((27, 40), "# lorem ipsum")
+        .add_string((41, 67), "    echo \"hello world\" && ")
+        .add_comment((73, 90), "# dolor sit amet,")
+        .add_comment((95, 110), "# consectetur \\")
+        .add_comment((115, 135), "# adipiscing elit, \\")
+        .add_comment((140, 156), "# sed do eiusmod")
+        .add_comment((161, 190), "# tempor incididunt ut labore")
+        .add_string((191, 207), "    echo foo && ")
+        .add_string((209, 224), "    echo 'bar' ")
+        .add_string((226, 242), "    && echo baz ")
+        .add_comment((248, 273), "# et dolore magna aliqua.")
+    );
+
+    assert_eq!(
+      ins.to_string(),
+      r#"set -x &&     echo "hello world" &&     echo foo &&     echo 'bar'     && echo baz "#
     );
 
     Ok(())

--- a/src/instructions/env.rs
+++ b/src/instructions/env.rs
@@ -3,8 +3,9 @@
 use std::convert::TryFrom;
 
 use crate::dockerfile_parser::Instruction;
-use crate::parser::{Pair, Rule};
 use crate::error::*;
+use crate::parser::{Pair, Rule};
+use crate::util::*;
 
 use enquote::unquote;
 use snafu::ResultExt;
@@ -13,15 +14,11 @@ use snafu::ResultExt;
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct EnvVar {
   pub key: String,
-  pub value: String
+  pub value: BreakableString,
 }
 
 impl EnvVar {
-  pub fn new<S1, S2>(key: S1, value: S2) -> EnvVar
-  where
-    S1: Into<String>,
-    S2: Into<String>,
-  {
+  pub fn new<S1: Into<String>>(key: S1, value: impl Into<BreakableString>) -> Self {
     EnvVar {
       key: key.into(),
       value: value.into(),
@@ -35,6 +32,18 @@ impl EnvVar {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct EnvInstruction(Vec<EnvVar>);
 
+impl From<EnvVar> for EnvInstruction {
+  fn from(var: EnvVar) -> Self {
+    EnvInstruction(vec![var])
+  }
+}
+
+impl From<Vec<EnvVar>> for EnvInstruction {
+  fn from(vars: Vec<EnvVar>) -> Self {
+    EnvInstruction(vars)
+  }
+}
+
 /// Parses an env pair token, e.g. key=value or key="value"
 fn parse_env_pair(record: Pair) -> Result<EnvVar> {
   let mut key = None;
@@ -43,11 +52,17 @@ fn parse_env_pair(record: Pair) -> Result<EnvVar> {
   for field in record.into_inner() {
     match field.as_rule() {
       Rule::env_pair_name => key = Some(field.as_str()),
-      Rule::env_pair_value => value = Some(field.as_str().to_string()),
+      Rule::env_pair_value => {
+        value = Some(
+          BreakableString::new(&field).add_string(&field, field.as_str())
+        );
+      },
       Rule::env_pair_quoted_value => {
         let v = unquote(field.as_str()).context(UnescapeError)?;
 
-        value = Some(v)
+        value = Some(
+          BreakableString::new(&field).add_string(&field, v)
+        );
       },
       _ => return Err(unexpected_token(field))
     }
@@ -65,6 +80,16 @@ fn parse_env_pair(record: Pair) -> Result<EnvVar> {
 }
 
 impl EnvInstruction {
+  pub fn new_single<S1>(key: S1, value: impl Into<BreakableString>) -> Self
+  where
+    S1: Into<String>
+  {
+    EnvInstruction(vec!(EnvVar {
+      key: key.into(),
+      value: value.into(),
+    }))
+  }
+
   pub(crate) fn from_pairs_record(record: Pair) -> Result<EnvInstruction> {
     let mut vars = Vec::new();
 
@@ -76,6 +101,29 @@ impl EnvInstruction {
     }
 
     Ok(EnvInstruction(vars))
+  }
+
+  pub(crate) fn from_single_record(record: Pair) -> Result<EnvInstruction> {
+    let mut key = None;
+    let mut value = None;
+
+    for field in record.into_inner() {
+      match field.as_rule() {
+        Rule::env_single_name => key = Some(field.as_str()),
+        Rule::env_single_value => value = Some(parse_any_breakable(field)?),
+        _ => return Err(unexpected_token(field))
+      }
+    }
+
+    let key = key.ok_or_else(|| Error::GenericParseError {
+      message: "env requires a key".into()
+    })?.to_string();
+
+    let value = value.ok_or_else(|| Error::GenericParseError {
+        message: "env requires a value".into()
+    })?;
+
+    Ok(EnvInstruction(vec![EnvVar { key, value }]))
   }
 }
 
@@ -96,6 +144,8 @@ impl<'a> TryFrom<&'a Instruction> for &'a EnvInstruction {
 
 #[cfg(test)]
 mod tests {
+  use indoc::indoc;
+
   use super::*;
   use crate::Dockerfile;
   use crate::test_util::*;
@@ -103,41 +153,108 @@ mod tests {
   #[test]
   fn env() -> Result<()> {
     assert_eq!(
-      parse_single(r#"env foo=bar"#, Rule::env)?,
-      EnvInstruction(vec![EnvVar::new("foo", "bar")]).into()
+      parse_single(r#"env foo=bar"#, Rule::env)?.into_env().unwrap(),
+      EnvInstruction(vec![EnvVar::new("foo", ((8, 11), "bar"))])
     );
 
     assert_eq!(
       parse_single(r#"env foo="bar""#, Rule::env)?,
-      EnvInstruction(vec![EnvVar::new("foo", "bar")]).into()
+      EnvInstruction(vec![EnvVar::new("foo", ((8, 13), "bar"))]).into()
     );
 
     assert_eq!(
       parse_single(r#"env foo="bar\"baz""#, Rule::env)?,
-      EnvInstruction(vec![EnvVar::new("foo", "bar\"baz")]).into()
+      EnvInstruction(vec![EnvVar::new("foo", ((8, 18), "bar\"baz"))]).into()
     );
 
     assert_eq!(
       parse_single(r#"env foo='bar'"#, Rule::env)?,
-      EnvInstruction(vec![EnvVar::new("foo", "bar")]).into()
+      EnvInstruction(vec![EnvVar::new("foo", ((8, 13), "bar"))]).into()
     );
 
     assert_eq!(
       parse_single(r#"env foo='bar\'baz'"#, Rule::env)?,
-      EnvInstruction(vec![EnvVar::new("foo", "bar'baz")]).into()
+      EnvInstruction(vec![EnvVar::new("foo", ((8, 18), "bar'baz"))]).into()
     );
 
     assert_eq!(
       parse_single(r#"env foo="123" bar='456' baz=789"#, Rule::env)?,
       EnvInstruction(vec![
-        EnvVar::new("foo", "123"),
-        EnvVar::new("bar", "456"),
-        EnvVar::new("baz", "789"),
+        EnvVar::new("foo", ((8, 13), "123")),
+        EnvVar::new("bar", ((18, 23), "456")),
+        EnvVar::new("baz", ((28, 31), "789")),
       ]).into()
     );
 
     assert!(Dockerfile::parse(r#"env foo="bar"bar"#).is_err());
     assert!(Dockerfile::parse(r#"env foo='bar'bar"#).is_err());
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_multiline_single_env() -> Result<()> {
+    assert_eq!(
+      parse_single(
+        indoc!(r#"
+          env foo Lorem ipsum dolor sit amet, \
+            consectetur adipiscing elit, \
+            sed do eiusmod tempor incididunt ut \
+            labore et dolore magna aliqua.
+        "#),
+        Rule::env
+      )?.into_env().unwrap().0,
+      vec![
+        EnvVar::new("foo", BreakableString::new((8, 143))
+          .add_string((8, 36), "Lorem ipsum dolor sit amet, ")
+          .add_string((38, 69), "  consectetur adipiscing elit, ")
+          .add_string((71, 109), "  sed do eiusmod tempor incididunt ut ")
+          .add_string((111, 143), "  labore et dolore magna aliqua.")
+        )
+      ]
+    );
+
+    // note: maybe a small bug here, leading whitespace on the first value line
+    // is eaten (this will hopefully never matter...)
+    assert_eq!(
+      parse_single(
+        indoc!(r#"
+          env \
+            foo \
+            Lorem ipsum dolor sit amet, \
+            consectetur adipiscing elit
+        "#),
+        Rule::env
+      )?.into_env().unwrap().0,
+      vec![
+        EnvVar::new("foo", BreakableString::new((16, 75))
+          .add_string((16, 44), "Lorem ipsum dolor sit amet, ")
+          .add_string((46, 75), "  consectetur adipiscing elit")
+        )
+      ]
+    );
+
+    assert_eq!(
+      parse_single(
+        indoc!(r#"
+          env \
+            foo \
+            # bar
+            Lorem ipsum dolor sit amet, \
+            # baz
+            consectetur adipiscing elit
+        "#),
+        Rule::env
+      )?.into_env().unwrap().0,
+      vec![
+        EnvVar::new("foo", BreakableString::new((16, 91))
+          .add_comment((16, 21), "# bar")
+          .add_string((22, 52), "  Lorem ipsum dolor sit amet, ")
+          .add_comment((56, 61), "# baz")
+          .add_string((62, 91), "  consectetur adipiscing elit")
+        )
+      ]
+    );
 
     Ok(())
   }

--- a/src/instructions/from.rs
+++ b/src/instructions/from.rs
@@ -36,6 +36,7 @@ impl FromInstruction {
       match field.as_rule() {
         Rule::from_image => image_field = Some(field),
         Rule::from_alias => alias_field = Some(field),
+        Rule::comment => continue,
         _ => return Err(unexpected_token(field))
       };
     }
@@ -89,6 +90,8 @@ impl<'a> TryFrom<&'a Instruction> for &'a FromInstruction {
 
 #[cfg(test)]
 mod tests {
+  use indoc::indoc;
+
   use super::*;
   use crate::test_util::*;
 
@@ -138,6 +141,45 @@ mod tests {
       "from alpine:3.10 as",
       Rule::dockerfile,
     ).is_err());
+
+    Ok(())
+  }
+
+  #[test]
+  fn from_multiline() -> Result<()> {
+    let from = parse_direct(
+      indoc!(r#"
+        from \
+          # foo
+          alpine:3.10 \
+
+          # test
+          # comment
+
+          as \
+
+          test
+      "#),
+      Rule::from,
+      |p| FromInstruction::from_record(p, 0)
+    )?;
+
+    println!("from: {:?}", &from);
+
+    assert_eq!(from, FromInstruction {
+      span: Span { start: 0, end: 68 },
+      index: 0,
+      image: "alpine:3.10".into(),
+      image_span: Span { start: 17, end: 28 },
+      image_parsed: ImageRef {
+        registry: None,
+        image: "alpine".into(),
+        tag: Some("3.10".into()),
+        hash: None
+      },
+      alias: Some("test".into()),
+      alias_span: Some((64, 68).into())
+    });
 
     Ok(())
   }

--- a/src/instructions/from.rs
+++ b/src/instructions/from.rs
@@ -164,8 +164,6 @@ mod tests {
       |p| FromInstruction::from_record(p, 0)
     )?;
 
-    println!("from: {:?}", &from);
-
     assert_eq!(from, FromInstruction {
       span: Span { start: 0, end: 68 },
       index: 0,

--- a/src/instructions/misc.rs
+++ b/src/instructions/misc.rs
@@ -17,7 +17,7 @@ use crate::parser::*;
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct MiscInstruction {
   instruction: String,
-  arguments: String
+  arguments: BreakableString
 }
 
 impl MiscInstruction {
@@ -28,7 +28,7 @@ impl MiscInstruction {
     for field in record.into_inner() {
       match field.as_rule() {
         Rule::misc_instruction => instruction = Some(field.as_str()),
-        Rule::misc_arguments => arguments = Some(field.as_str()),
+        Rule::misc_arguments => arguments = Some(parse_any_breakable(field)?),
         _ => return Err(unexpected_token(field))
       }
     }
@@ -37,9 +37,9 @@ impl MiscInstruction {
       message: "generic instructions require a name".into()
     })?.to_string();
 
-    let arguments = clean_escaped_breaks(arguments.ok_or_else(|| Error::GenericParseError {
+    let arguments = arguments.ok_or_else(|| Error::GenericParseError {
       message: "generic instructions require arguments".into()
-    })?);
+    })?;
 
     Ok(MiscInstruction {
       instruction, arguments

--- a/src/instructions/run.rs
+++ b/src/instructions/run.rs
@@ -138,6 +138,16 @@ mod tests {
       "echo   \"hello world\""
     );
 
+    // whitespace should be allowed, but my editor removes trailing whitespace
+    // :)
+    assert_eq!(
+      parse_single("run echo \\    \t  \t\t\n  \"hello world\"", Rule::run)?
+        .as_run().unwrap()
+        .as_shell().unwrap()
+        .to_string(),
+      "echo   \"hello world\""
+    );
+
     Ok(())
   }
 

--- a/src/instructions/run.rs
+++ b/src/instructions/run.rs
@@ -15,7 +15,7 @@ use crate::parser::*;
 /// [run]: https://docs.docker.com/engine/reference/builder/#run
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RunInstruction {
-  Shell(String),
+  Shell(BreakableString),
   Exec(Vec<String>)
 }
 
@@ -25,15 +25,51 @@ impl RunInstruction {
   }
 
   pub(crate) fn from_shell_record(record: Pair) -> Result<RunInstruction> {
-    Ok(RunInstruction::Shell(record.as_str().to_string()))
-  }
-
-  pub fn shell<S: Into<String>>(s: S) -> RunInstruction {
-    RunInstruction::Shell(s.into())
+    Ok(RunInstruction::Shell(parse_any_breakable(record)?))
   }
 
   pub fn exec<S: Into<String>>(args: Vec<S>) -> RunInstruction {
     RunInstruction::Exec(args.into_iter().map(|s| s.into()).collect())
+  }
+
+  /// Unpacks this instruction into its inner value if it is a Shell-form
+  /// instruction, otherwise returns None.
+  pub fn into_shell(self) -> Option<BreakableString> {
+    if let RunInstruction::Shell(s) = self {
+      Some(s)
+    } else {
+      None
+    }
+  }
+
+  /// Unpacks this instruction into its inner value if it is a Shell-form
+  /// instruction, otherwise returns None.
+  pub fn as_shell(&self) -> Option<&BreakableString> {
+    if let RunInstruction::Shell(s) = self {
+      Some(s)
+    } else {
+      None
+    }
+  }
+
+  /// Unpacks this instruction into its inner value if it is an Exec-form
+  /// instruction, otherwise returns None.
+  pub fn into_exec(self) -> Option<Vec<String>> {
+    if let RunInstruction::Exec(s) = self {
+      Some(s)
+    } else {
+      None
+    }
+  }
+
+  /// Unpacks this instruction into its inner value if it is an Exec-form
+  /// instruction, otherwise returns None.
+  pub fn as_exec(&self) -> Option<&Vec<String>> {
+    if let RunInstruction::Exec(s) = self {
+      Some(s)
+    } else {
+      None
+    }
   }
 }
 
@@ -62,8 +98,11 @@ mod tests {
   #[test]
   fn run_basic() -> Result<()> {
     assert_eq!(
-      parse_single(r#"run echo "hello world""#, Rule::run)?,
-      RunInstruction::shell("echo \"hello world\"").into()
+      parse_single(r#"run echo "hello world""#, Rule::run)?
+        .as_run().unwrap()
+        .as_shell().unwrap(),
+      &BreakableString::new((4, 22))
+        .add_string((4, 22), "echo \"hello world\"")
     );
 
     assert_eq!(
@@ -75,22 +114,28 @@ mod tests {
   }
 
   #[test]
-  fn run_multiline() -> Result<()> {
+  fn run_multiline_shell() -> Result<()> {
     assert_eq!(
       parse_single(indoc!(r#"
         run echo \
           "hello world"
-      "#), Rule::run)?,
-      RunInstruction::shell("echo \\\n  \"hello world\"").into()
+      "#), Rule::run)?
+        .as_run().unwrap()
+        .as_shell().unwrap(),
+      &BreakableString::new((4, 26))
+        .add_string((4, 9), "echo ")
+        .add_string((11, 26), "  \"hello world\"")
     );
 
     assert_eq!(
-      parse_single(r#"run\
-        [\
-        "echo", \
-        "hello world"\
-        ]"#, Rule::run)?,
-      RunInstruction::exec(vec!["echo", "hello world"]).into()
+      parse_single(indoc!(r#"
+        run echo \
+          "hello world"
+      "#), Rule::run)?
+        .as_run().unwrap()
+        .as_shell().unwrap()
+        .to_string(),
+      "echo   \"hello world\""
     );
 
     Ok(())
@@ -98,7 +143,6 @@ mod tests {
 
   #[test]
   fn run_multiline_shell_comment() -> Result<()> {
-    // TODO: consider ways to mangle this string less
     assert_eq!(
       parse_single(
         indoc!(r#"
@@ -109,44 +153,27 @@ mod tests {
               baz
         "#),
         Rule::run
-      )?,
-      RunInstruction::shell(indoc!(r#"
-        foo && \
-            # implicitly escaped
-            bar && \
-            # explicitly escaped \
-            baz"#)).into()
+      )?
+        .into_run().unwrap()
+        .into_shell().unwrap(),
+      BreakableString::new((4, 85))
+        .add_string((4, 11), "foo && ")
+        .add_comment((17, 37), "# implicitly escaped")
+        .add_string((38, 49), "    bar && ")
+        .add_comment((55, 77), "# explicitly escaped \\")
+        .add_string((78, 85), "    baz")
     );
 
-    assert_eq!(
-      parse_single(r#"run\
-        [\
-        "echo", \
-        "hello world"\
-        ]"#, Rule::run)?,
-      RunInstruction::exec(vec!["echo", "hello world"]).into()
-    );
+    Ok(())
+  }
 
-    assert_eq!(
-      parse_single(
-        indoc!(r#"
-          run set -x && \
-              # lorem ipsum
-              echo "hello world" && \
-              # dolor sit amet,
-              # consectetur \
-              # adipiscing elit, \
-              # sed do eiusmod
-              # tempor incididunt ut labore
-              echo foo && \
-              echo 'bar' \
-              && echo baz \
-              # et dolore magna aliqua.
-        "#),
-        Rule::run
-      )?,
-      RunInstruction::shell(indoc!(r#"
-        set -x && \
+  #[test]
+  fn run_multiline_shell_large() -> Result<()> {
+    // note: the trailing `\` at the end is _almost_ nonsense and generates a
+    // warning from docker
+    let ins = parse_single(
+      indoc!(r#"
+        run set -x && \
             # lorem ipsum
             echo "hello world" && \
             # dolor sit amet,
@@ -157,15 +184,51 @@ mod tests {
             echo foo && \
             echo 'bar' \
             && echo baz \
-            # et dolore magna aliqua.
-      "#)).into()
+            # et dolore magna aliqua."#),
+      Rule::run
+    )?.into_run().unwrap().into_shell().unwrap();
+
+    assert_eq!(
+      ins,
+      BreakableString::new((4, 266))
+        .add_string((4, 14), "set -x && ")
+        .add_comment((20, 33), "# lorem ipsum")
+        .add_string((34, 60), "    echo \"hello world\" && ")
+        .add_comment((66, 83), "# dolor sit amet,")
+        .add_comment((88, 103), "# consectetur \\")
+        .add_comment((108, 128), "# adipiscing elit, \\")
+        .add_comment((133, 149), "# sed do eiusmod")
+        .add_comment((154, 183), "# tempor incididunt ut labore")
+        .add_string((184, 200), "    echo foo && ")
+        .add_string((202, 217), "    echo 'bar' ")
+        .add_string((219, 235), "    && echo baz ")
+        .add_comment((241, 266), "# et dolore magna aliqua.")
+    );
+
+    assert_eq!(
+      ins.to_string(),
+      r#"set -x &&     echo "hello world" &&     echo foo &&     echo 'bar'     && echo baz "#
     );
 
     Ok(())
   }
 
   #[test]
-  fn test_multiline_exec_comment() -> Result<()> {
+  fn run_multline_exec() -> Result<()> {
+    assert_eq!(
+      parse_single(r#"run\
+        [\
+        "echo", \
+        "hello world"\
+        ]"#, Rule::run)?,
+      RunInstruction::exec(vec!["echo", "hello world"]).into()
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn run_multiline_exec_comment() -> Result<()> {
     assert_eq!(
       parse_single(r#"run\
         [\

--- a/src/instructions/run.rs
+++ b/src/instructions/run.rs
@@ -56,6 +56,8 @@ impl<'a> TryFrom<&'a Instruction> for &'a RunInstruction {
 
 #[cfg(test)]
 mod tests {
+  use indoc::indoc;
+
   use super::*;
   use crate::test_util::*;
 
@@ -80,6 +82,35 @@ mod tests {
       parse_single(r#"run echo \
         "hello world""#, Rule::run)?,
       RunInstruction::shell("echo         \"hello world\"").into()
+    );
+
+    assert_eq!(
+      parse_single(r#"run\
+        [\
+        "echo", \
+        "hello world"\
+        ]"#, Rule::run)?,
+      RunInstruction::exec(vec!["echo", "hello world"]).into()
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn run_multiline_comment() -> Result<()> {
+    assert_eq!(
+      parse_single(
+        indoc!(r#"
+          run foo \
+              # hello world
+              bar \
+              baz
+        "#),
+        Rule::run
+      )?,
+      RunInstruction::shell(indoc!(r#"
+        foo
+      "#)).into()
     );
 
     assert_eq!(

--- a/src/instructions/run.rs
+++ b/src/instructions/run.rs
@@ -98,19 +98,20 @@ mod tests {
 
   #[test]
   fn run_multiline_comment() -> Result<()> {
+    // TODO: consider ways to mangle this string less
     assert_eq!(
       parse_single(
         indoc!(r#"
-          run foo \
+          run foo && \
               # hello world
-              bar \
+              bar && \
               baz
         "#),
         Rule::run
       )?,
       RunInstruction::shell(indoc!(r#"
-        foo
-      "#)).into()
+        foo &&     # hello world
+            bar &&     baz"#)).into()
     );
 
     assert_eq!(

--- a/src/splicer.rs
+++ b/src/splicer.rs
@@ -14,7 +14,7 @@ struct SpliceOffset {
 }
 
 /// A byte-index tuple representing a span of characters in a string
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone, Ord, PartialOrd)]
 pub struct Span {
   pub start: usize,
   pub end: usize
@@ -83,6 +83,12 @@ impl Span {
 impl From<(usize, usize)> for Span {
   fn from(tup: (usize, usize)) -> Span {
     Span::new(tup.0, tup.1)
+  }
+}
+
+impl From<&Pair<'_>> for Span {
+  fn from(pair: &Pair<'_>) -> Self {
+    Span::from_pair(&pair)
   }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,6 +21,7 @@ pub(crate) fn parse_string_array(array: Pair) -> Result<Vec<String>> {
 
         ret.push(s);
       },
+      Rule::comment => continue,
       _ => return Err(unexpected_token(field))
     }
   }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,10 @@
 // (C) Copyright 2019 Hewlett Packard Enterprise Development LP
 
+use std::fmt;
+
 use crate::error::*;
 use crate::parser::*;
+use crate::splicer::Span;
 
 use enquote::unquote;
 use snafu::ResultExt;
@@ -30,4 +33,154 @@ pub(crate) fn parse_string_array(array: Pair) -> Result<Vec<String>> {
 /// This should be used to clean any input from the any_breakable rule
 pub(crate) fn clean_escaped_breaks(s: &str) -> String {
   s.replace("\\\n", "")
+}
+
+/// A comment with a character span.
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
+pub struct SpannedComment {
+  pub span: Span,
+  pub content: String,
+}
+
+/// A string with a character span.
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
+pub struct SpannedString {
+  pub span: Span,
+  pub content: String,
+}
+
+/// A component of a breakable string.
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
+pub enum BreakableStringComponent {
+  String(SpannedString),
+  Comment(SpannedComment),
+}
+
+impl From<SpannedString> for BreakableStringComponent {
+  fn from(s: SpannedString) -> Self {
+    BreakableStringComponent::String(s)
+  }
+}
+
+impl From<((usize, usize), &str)> for BreakableStringComponent {
+  fn from(s: ((usize, usize), &str)) -> Self {
+    let ((start, end), content) = s;
+
+    BreakableStringComponent::String(SpannedString {
+      span: (start, end).into(),
+      content: content.to_string(),
+    })
+  }
+}
+
+impl From<SpannedComment> for BreakableStringComponent {
+  fn from(c: SpannedComment) -> Self {
+    BreakableStringComponent::Comment(c)
+  }
+}
+
+/// A Docker string that may be broken across several lines, separated by line
+/// continuations (`\\\n`), and possibly intermixed with comments.
+///
+/// These strings have several potentially valid interpretations. As these line
+/// continuations match those natively supported by bash, a given multiline
+/// `RUN` block can be pasted into a bash shell unaltered and with line
+/// continuations included. However, at "runtime" line continuations and
+/// comments (*) are stripped from the string handed to the shell.
+///
+/// To ensure output is correct in all cases, `BreakableString` preserves the
+/// user's original AST, including comments, and implements Docker's
+/// continuation-stripping behavior in the `Display` implementation.
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
+pub struct BreakableString {
+  pub span: Span,
+  pub components: Vec<BreakableStringComponent>,
+}
+
+/// Formats this breakable string as it will be interpreted by the underlying
+/// Docker engine, i.e. on a single line with line continuations removed
+impl fmt::Display for BreakableString {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    for component in &self.components {
+      if let BreakableStringComponent::String(s) = &component {
+        write!(f, "{}", s.content)?;
+      }
+    }
+
+    Ok(())
+  }
+}
+
+impl BreakableString {
+  pub fn new(span: impl Into<Span>) -> Self {
+    BreakableString {
+      span: span.into(),
+      components: Vec::new(),
+    }
+  }
+
+  pub fn add(mut self, c: impl Into<BreakableStringComponent>) -> Self {
+    self.components.push(c.into());
+
+    self
+  }
+
+  pub fn add_string(mut self, s: impl Into<Span>, c: impl Into<String>) -> Self {
+    self.components.push(SpannedString {
+      span: s.into(),
+      content: c.into(),
+    }.into());
+
+    self
+  }
+
+  pub fn add_comment(mut self, s: impl Into<Span>, c: impl Into<String>) -> Self {
+    self.components.push(SpannedComment {
+      span: s.into(),
+      content: c.into(),
+    }.into());
+
+    self
+  }
+
+  pub fn iter_components(&self) -> impl Iterator<Item = &BreakableStringComponent> {
+    self.components.iter()
+  }
+}
+
+impl From<((usize, usize), &str)> for BreakableString {
+  fn from(s: ((usize, usize), &str)) -> Self {
+    let ((start, end), content) = s;
+
+    BreakableString::new((start, end))
+      .add_string((start, end), content)
+  }
+}
+
+fn parse_any_breakable_inner(pair: Pair) -> Result<Vec<BreakableStringComponent>> {
+  let mut components = Vec::new();
+
+  for field in pair.into_inner() {
+    match field.as_rule() {
+      Rule::any_breakable => components.extend(parse_any_breakable_inner(field)?),
+      Rule::comment => components.push(SpannedComment {
+        span: (&field).into(),
+        content: field.as_str().to_string(),
+      }.into()),
+      Rule::any_content => components.push(SpannedString {
+        span: (&field).into(),
+        content: field.as_str().to_string(),
+      }.into()),
+      _ => return Err(unexpected_token(field))
+    }
+  }
+
+  Ok(components)
+}
+
+pub(crate) fn parse_any_breakable(pair: Pair) -> Result<BreakableString> {
+  Ok(BreakableString {
+    span: (&pair).into(),
+    components: parse_any_breakable_inner(pair)?,
+  })
 }

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -3,6 +3,7 @@
 extern crate dockerfile_parser;
 
 use dockerfile_parser::*;
+use indoc::indoc;
 
 mod common;
 use common::*;
@@ -45,12 +46,12 @@ fn parse_basic() -> Result<(), dockerfile_parser::Error> {
 
 #[test]
 fn parse_multiline_shell() -> Result<(), dockerfile_parser::Error> {
-  let dockerfile = Dockerfile::parse(r#"
+  let dockerfile = Dockerfile::parse(indoc!(r#"
     RUN apk add --no-cache \
         curl
 
     RUN foo
-  "#)?;
+  "#))?;
 
   assert_eq!(dockerfile.instructions.len(), 2);
 
@@ -58,7 +59,7 @@ fn parse_multiline_shell() -> Result<(), dockerfile_parser::Error> {
   assert_eq!(
     dockerfile.instructions[0],
     Instruction::Run(RunInstruction::Shell(
-      "apk add --no-cache         curl".into()
+      "apk add --no-cache \\\n    curl".into()
     ))
   );
 

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -37,8 +37,11 @@ fn parse_basic() -> Result<(), dockerfile_parser::Error> {
   );
 
   assert_eq!(
-    dockerfile.instructions[1],
-    Instruction::Run(RunInstruction::Shell("apk add --no-cache curl".into()))
+    &dockerfile.instructions[1]
+      .as_run().unwrap()
+      .as_shell().unwrap()
+      .to_string(),
+    "apk add --no-cache curl"
   );
 
   Ok(())
@@ -57,15 +60,19 @@ fn parse_multiline_shell() -> Result<(), dockerfile_parser::Error> {
 
   // note: 9 spaces due to 1 before the \ + 8 for indent
   assert_eq!(
-    dockerfile.instructions[0],
-    Instruction::Run(RunInstruction::Shell(
-      "apk add --no-cache \\\n    curl".into()
-    ))
+    &dockerfile.instructions[0]
+      .as_run().unwrap()
+      .as_shell().unwrap()
+      .to_string(),
+    "apk add --no-cache     curl"
   );
 
   assert_eq!(
-    dockerfile.instructions[1],
-    Instruction::Run(RunInstruction::Shell("foo".into()))
+    &dockerfile.instructions[1]
+      .as_run().unwrap()
+      .as_shell().unwrap()
+      .to_string(),
+    "foo"
   );
 
   Ok(())
@@ -93,8 +100,11 @@ fn parse_multiline_exec() -> Result<(), dockerfile_parser::Error> {
   );
 
   assert_eq!(
-    dockerfile.instructions[1],
-    Instruction::Run(RunInstruction::Shell("foo".into()))
+    &dockerfile.instructions[1]
+      .as_run().unwrap()
+      .as_shell().unwrap()
+      .to_string(),
+    "foo"
   );
 
   Ok(())
@@ -118,10 +128,11 @@ fn parse_label() -> Result<(), dockerfile_parser::Error> {
   assert_eq!(dockerfile.instructions.len(), 5);
 
   assert_eq!(
-    dockerfile.instructions[0],
-    Instruction::Label(LabelInstruction(vec![
+    dockerfile.instructions[0]
+      .as_label().unwrap(),
+    &LabelInstruction(vec![
       Label::new("foo", "bar")
-    ]))
+    ])
   );
 
   assert_eq!(
@@ -146,8 +157,11 @@ fn parse_label() -> Result<(), dockerfile_parser::Error> {
   );
 
   assert_eq!(
-    dockerfile.instructions[4],
-    Instruction::Run(RunInstruction::Shell("foo".into()))
+    &dockerfile.instructions[4]
+      .as_run().unwrap()
+      .as_shell().unwrap()
+      .to_string(),
+    "foo"
   );
 
   Ok(())
@@ -180,8 +194,11 @@ fn parse_comment() -> Result<(), dockerfile_parser::Error> {
   assert_eq!(dockerfile.instructions.len(), 5);
 
   assert_eq!(
-    dockerfile.instructions[4],
-    Instruction::Run(RunInstruction::Shell("foo".into()))
+    &dockerfile.instructions[4]
+      .as_run().unwrap()
+      .as_shell().unwrap()
+      .to_string(),
+    "foo"
   );
 
   Ok(())

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -210,9 +210,11 @@ fn parse_comment() -> Result<(), dockerfile_parser::Error> {
       "hello", \
       "world" \
     ]
+
+    run echo 'hello # world'
   "#)?;
 
-  assert_eq!(dockerfile.instructions.len(), 7);
+  assert_eq!(dockerfile.instructions.len(), 8);
 
   assert_eq!(
     &dockerfile.instructions[4]
@@ -235,6 +237,14 @@ fn parse_comment() -> Result<(), dockerfile_parser::Error> {
       .as_run().unwrap()
       .as_exec().unwrap(),
     &vec!["echo", "hello", "world"]
+  );
+
+  assert_eq!(
+    dockerfile.instructions[7]
+      .as_run().unwrap()
+      .as_shell().unwrap()
+      .to_string(),
+    "echo 'hello # world'"
   );
 
   Ok(())


### PR DESCRIPTION
Grammar changes to allow comments and empty lines to be written in multiline blocks in any position that line continuations should be allowed and without explicit end-of-line escapes, for example:

```Dockerfile
RUN foo && \ 
    # test comment
    bar && \
    baz

CMD [ \
  # comment
  "foo" \
  "bar" \
]

ENV \
  foo=a \
  # comment
  bar=b \

  # empty lines too

  baz=c

COPY \
  --from=foo \
  # comment
  /src \
  /dest
```

To support this, a new `String` wrapper was added, `BreakableString`, to preserve the user-provided formatting (long strings were presumably hand-wrapped for readability purposes) while adding the ability to accurately compute the string Docker actually executes in e.g. a `RUN` block. Comments inside shell-style `RUN`, `CMD`, `ENTRYPOINT`, and other users of the `any_breakable` rule are now available as part of ordered segments inside `BreakableString`, but alternatively the `Display` implementation (or `.to_string()`) can be used to format the string onto a single line (sans comments) as Docker would. Many new tests were added to account for the (many) edge cases.

Note that this is a potentially breaking change due to `BreakableString` replacing `String` in several API locations. To upgrade preserving functionality (with better inline comment handling), use `BreakableString`'s `Display` implementation.

Additionally, a number of helper methods were added to aid in extracting enum types, including `Instruction::into_*` and `Instruction::as_*` to explicitly convert without relying on (sometimes impossible) type inference using the existing `TryFrom` implementations.