### PR TITLE
feat: provide span for more nodes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: rust:1.42-slim-buster
+      - image: rust:1.55-slim-buster
     steps:
       - checkout
       - run:
@@ -19,7 +19,7 @@ jobs:
 
   publish:
     docker:
-      - image: rust:1.42-slim-buster
+      - image: rust:1.55-slim-buster
     steps:
       - checkout
       - run:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ lazy_static = "1.4"
 
 [dev-dependencies]
 indoc = "0.3"
+pretty_assertions = "0.7.2"
 
 [lib]
 name = "dockerfile_parser"

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ errors in addition to a full syntax tree.
 ## Limitations
 
  * Buildkit parser directives are not handled at all.
- * Not all instructions record spans; feel free to file an issue if some use
-   case is missing a span
  * Unknown instructions are parsed as `MiscInstruction` rather than producing
    an explicit error. A number of valid but less interesting Docker instructions
    are handled this way, e.g. `ONBUILD`, `MAINTAINER`, etc. See notes in

--- a/examples/splice.rs
+++ b/examples/splice.rs
@@ -16,7 +16,7 @@ fn wrap() -> Result<()> {
 
   for ins in dockerfile.instructions {
     if let Instruction::From(f) = ins {
-      splicer.splice(&f.image_span, "splice:test");
+      splicer.splice(&f.image.span, "splice:test");
     }
   }
 

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -125,15 +125,15 @@ label = { ^"label" ~ (label_single | (arg_ws ~ label_pair?)+) }
 
 run_shell = @{ any_breakable }
 run_exec = { string_array }
-run = _{ ^"run" ~ arg_ws ~ (run_exec | run_shell) }
+run = { ^"run" ~ arg_ws ~ (run_exec | run_shell) }
 
 entrypoint_shell = @{ any_breakable }
 entrypoint_exec = { string_array }
-entrypoint = _{ ^"entrypoint" ~ arg_ws ~ (entrypoint_exec | entrypoint_shell) }
+entrypoint = { ^"entrypoint" ~ arg_ws ~ (entrypoint_exec | entrypoint_shell) }
 
 cmd_shell = @{ any_breakable }
 cmd_exec = { string_array }
-cmd = _{ ^"cmd" ~ arg_ws ~ (cmd_exec | cmd_shell) }
+cmd = { ^"cmd" ~ arg_ws ~ (cmd_exec | cmd_shell) }
 
 copy_flag_name = @{ ASCII_ALPHA+ }
 copy_flag_value = @{ any_whitespace }
@@ -149,7 +149,7 @@ env_pairs = { (arg_ws ~ env_pair?)+ }
 env_single_quoted_value = ${ string }
 env_single_value = @{ any_breakable }
 env_single = {  arg_ws ~ env_name ~ arg_ws ~ (env_single_quoted_value | env_single_value) }
-env = _{ ^"env" ~ (env_single | env_pairs) }
+env = { ^"env" ~ (env_single | env_pairs) }
 
 misc_instruction = @{ ASCII_ALPHA+ }
 misc_arguments = @{ any_breakable }

--- a/src/dockerfile_parser.rs
+++ b/src/dockerfile_parser.rs
@@ -207,6 +207,21 @@ impl Instruction {
       _ => None,
     }
   }
+
+  /// Gets the span of the instruction.
+  pub fn span(&self) -> Span {
+    match self {
+      Instruction::From(instruction) => instruction.span,
+      Instruction::Arg(instruction) => instruction.span,
+      Instruction::Label(instruction) => instruction.span,
+      Instruction::Run(instruction) => instruction.span,
+      Instruction::Entrypoint(instruction) => instruction.span,
+      Instruction::Cmd(instruction) => instruction.span,
+      Instruction::Copy(instruction) => instruction.span,
+      Instruction::Env(instruction) => instruction.span,
+      Instruction::Misc(instruction) => instruction.span,
+    }
+  }
 }
 
 /// Maps an instruction struct to its enum variant, implementing From<T> on
@@ -240,21 +255,15 @@ impl TryFrom<Pair<'_>> for Instruction {
       Rule::arg => ArgInstruction::from_record(record)?.into(),
       Rule::label => LabelInstruction::from_record(record)?.into(),
 
-      Rule::run_exec => RunInstruction::from_exec_record(record)?.into(),
-      Rule::run_shell => RunInstruction::from_shell_record(record)?.into(),
+      Rule::run => RunInstruction::from_record(record)?.into(),
 
-      Rule::entrypoint_exec =>
-        EntrypointInstruction::from_exec_record(record)?.into(),
-      Rule::entrypoint_shell =>
-        EntrypointInstruction::from_shell_record(record)?.into(),
+      Rule::entrypoint => EntrypointInstruction::from_record(record)?.into(),
 
-      Rule::cmd_exec => CmdInstruction::from_exec_record(record)?.into(),
-      Rule::cmd_shell => CmdInstruction::from_shell_record(record)?.into(),
+      Rule::cmd => CmdInstruction::from_record(record)?.into(),
 
       Rule::copy => Instruction::Copy(CopyInstruction::from_record(record)?),
 
-      Rule::env_single => EnvInstruction::from_single_record(record)?.into(),
-      Rule::env_pairs => EnvInstruction::from_pairs_record(record)?.into(),
+      Rule::env => EnvInstruction::from_record(record)?.into(),
 
       Rule::misc => MiscInstruction::from_record(record)?.into(),
 
@@ -393,7 +402,7 @@ impl Dockerfile {
     for ins in &self.instructions {
       match ins {
         Instruction::Arg(a) => {
-          if a.name == name {
+          if a.name.content == name {
             return Some(a);
           } else {
             continue

--- a/src/image.rs
+++ b/src/image.rs
@@ -156,8 +156,8 @@ impl ImageRef {
     let vars: HashMap<&'a str, &'a str> = HashMap::from_iter(
       dockerfile.global_args
         .iter()
-        .filter_map(|a| match a.value.as_deref() {
-          Some(v) => Some((a.name.as_str(), v)),
+        .filter_map(|a| match a.value.as_ref() {
+          Some(v) => Some((a.name.as_str(), v.as_str())),
           None => None
         })
     );

--- a/src/image.rs
+++ b/src/image.rs
@@ -157,7 +157,7 @@ impl ImageRef {
       dockerfile.global_args
         .iter()
         .filter_map(|a| match a.value.as_ref() {
-          Some(v) => Some((a.name.as_str(), v.as_str())),
+          Some(v) => Some((a.name.as_ref(), v.as_ref())),
           None => None
         })
     );

--- a/src/instructions/cmd.rs
+++ b/src/instructions/cmd.rs
@@ -2,6 +2,7 @@
 
 use std::convert::TryFrom;
 
+use crate::Span;
 use crate::dockerfile_parser::Instruction;
 use crate::error::*;
 use crate::util::*;
@@ -14,62 +15,51 @@ use crate::parser::*;
 ///
 /// [cmd]: https://docs.docker.com/engine/reference/builder/#cmd
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub enum CmdInstruction {
-  Shell(BreakableString),
-  Exec(Vec<String>)
+pub struct CmdInstruction {
+  pub span: Span,
+  pub expr: ShellOrExecExpr,
 }
 
 impl CmdInstruction {
-  pub(crate) fn from_exec_record(record: Pair) -> Result<CmdInstruction> {
-    Ok(CmdInstruction::Exec(parse_string_array(record)?))
-  }
+  pub(crate) fn from_record(record: Pair) -> Result<CmdInstruction> {
+    let span = Span::from_pair(&record);
+    let field = record.into_inner().next().unwrap();
 
-  pub(crate) fn from_shell_record(record: Pair) -> Result<CmdInstruction> {
-    Ok(CmdInstruction::Shell(parse_any_breakable(record)?))
-  }
-
-  pub fn exec<S: Into<String>>(args: Vec<S>) -> CmdInstruction {
-    CmdInstruction::Exec(args.into_iter().map(|s| s.into()).collect())
+    match field.as_rule() {
+      Rule::cmd_exec => Ok(CmdInstruction {
+        span,
+        expr: ShellOrExecExpr::Exec(parse_string_array(field)?),
+      }),
+      Rule::cmd_shell => Ok(CmdInstruction {
+        span,
+        expr: ShellOrExecExpr::Shell(parse_any_breakable(field)?),
+      }),
+      _ => Err(unexpected_token(field)),
+    }
   }
 
   /// Unpacks this instruction into its inner value if it is a Shell-form
   /// instruction, otherwise returns None.
   pub fn into_shell(self) -> Option<BreakableString> {
-    if let CmdInstruction::Shell(s) = self {
-      Some(s)
-    } else {
-      None
-    }
+    self.expr.into_shell()
   }
 
   /// Unpacks this instruction into its inner value if it is a Shell-form
   /// instruction, otherwise returns None.
   pub fn as_shell(&self) -> Option<&BreakableString> {
-    if let CmdInstruction::Shell(s) = self {
-      Some(s)
-    } else {
-      None
-    }
+    self.expr.as_shell()
   }
 
   /// Unpacks this instruction into its inner value if it is an Exec-form
   /// instruction, otherwise returns None.
-  pub fn into_exec(self) -> Option<Vec<String>> {
-    if let CmdInstruction::Exec(s) = self {
-      Some(s)
-    } else {
-      None
-    }
+  pub fn into_exec(self) -> Option<StringArray> {
+    self.expr.into_exec()
   }
 
   /// Unpacks this instruction into its inner value if it is an Exec-form
   /// instruction, otherwise returns None.
-  pub fn as_exec(&self) -> Option<&Vec<String>> {
-    if let CmdInstruction::Exec(s) = self {
-      Some(s)
-    } else {
-      None
-    }
+  pub fn as_exec(&self) -> Option<&StringArray> {
+    self.expr.as_exec()
   }
 }
 
@@ -91,8 +81,10 @@ impl<'a> TryFrom<&'a Instruction> for &'a CmdInstruction {
 #[cfg(test)]
 mod tests {
   use indoc::indoc;
+  use pretty_assertions::assert_eq;
 
   use super::*;
+  use crate::Span;
   use crate::test_util::*;
 
   #[test]
@@ -115,7 +107,19 @@ mod tests {
 
     assert_eq!(
       parse_single(r#"cmd ["echo", "hello world"]"#, Rule::cmd)?,
-      CmdInstruction::exec(vec!["echo", "hello world"]).into()
+      CmdInstruction {
+        span: Span::new(0, 27),
+        expr: ShellOrExecExpr::Exec(StringArray {
+          span: Span::new(4, 27),
+          elements: vec![SpannedString {
+            span: Span::new(5, 11),
+            content: "echo".to_string(),
+          }, SpannedString {
+            span: Span::new(13, 26),
+            content: "hello world".to_string(),
+          }]
+        }),
+      }.into()
     );
 
     Ok(())
@@ -129,7 +133,19 @@ mod tests {
         "echo", \
         "hello world"\
         ]"#, Rule::cmd)?,
-      CmdInstruction::exec(vec!["echo", "hello world"]).into()
+      CmdInstruction {
+        span: Span::new(0, 66),
+        expr: ShellOrExecExpr::Exec(StringArray {
+          span: Span::new(13, 66),
+          elements: vec![SpannedString {
+            span: Span::new(24, 30),
+            content: "echo".to_string(),
+          }, SpannedString {
+            span: Span::new(42, 55),
+            content: "hello world".to_string(),
+          }]
+        }),
+      }.into()
     );
 
     Ok(())

--- a/src/instructions/env.rs
+++ b/src/instructions/env.rs
@@ -3,6 +3,7 @@
 use std::convert::TryFrom;
 
 use crate::dockerfile_parser::Instruction;
+use crate::Span;
 use crate::error::*;
 use crate::parser::{Pair, Rule};
 use crate::util::*;
@@ -13,14 +14,16 @@ use snafu::ResultExt;
 /// An environment variable key/value pair
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct EnvVar {
-  pub key: String,
+  pub span: Span,
+  pub key: SpannedString,
   pub value: BreakableString,
 }
 
 impl EnvVar {
-  pub fn new<S1: Into<String>>(key: S1, value: impl Into<BreakableString>) -> Self {
+  pub fn new(span: Span, key: SpannedString, value: impl Into<BreakableString>) -> Self {
     EnvVar {
-      key: key.into(),
+      span,
+      key: key,
       value: value.into(),
     }
   }
@@ -30,28 +33,20 @@ impl EnvVar {
 ///
 /// [env]: https://docs.docker.com/engine/reference/builder/#env
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct EnvInstruction(pub Vec<EnvVar>);
-
-impl From<EnvVar> for EnvInstruction {
-  fn from(var: EnvVar) -> Self {
-    EnvInstruction(vec![var])
-  }
-}
-
-impl From<Vec<EnvVar>> for EnvInstruction {
-  fn from(vars: Vec<EnvVar>) -> Self {
-    EnvInstruction(vars)
-  }
+pub struct EnvInstruction {
+  pub span: Span,
+  pub vars: Vec<EnvVar>
 }
 
 /// Parses an env pair token, e.g. key=value or key="value"
 fn parse_env_pair(record: Pair) -> Result<EnvVar> {
+  let span = Span::from_pair(&record);
   let mut key = None;
   let mut value = None;
 
   for field in record.into_inner() {
     match field.as_rule() {
-      Rule::env_name => key = Some(field.as_str()),
+      Rule::env_name => key = Some(parse_string(&field)?),
       Rule::env_pair_value => {
         value = Some(
           BreakableString::new(&field).add_string(&field, field.as_str())
@@ -70,27 +65,32 @@ fn parse_env_pair(record: Pair) -> Result<EnvVar> {
 
   let key = key.ok_or_else(|| Error::GenericParseError {
     message: "env pair requires a key".into()
-  })?.to_string();
+  })?;
 
   let value = value.ok_or_else(|| Error::GenericParseError {
     message: "env pair requires a value".into()
   })?;
 
-  Ok(EnvVar { key, value })
+  Ok(EnvVar {
+    span,
+    key,
+    value,
+  })
 }
 
 impl EnvInstruction {
-  pub fn new_single<S1>(key: S1, value: impl Into<BreakableString>) -> Self
-  where
-    S1: Into<String>
-  {
-    EnvInstruction(vec!(EnvVar {
-      key: key.into(),
-      value: value.into(),
-    }))
+  pub(crate) fn from_record(record: Pair) -> Result<EnvInstruction> {
+    let span = Span::from_pair(&record);
+    let field = record.into_inner().next().unwrap();
+
+    match field.as_rule() {
+      Rule::env_single => EnvInstruction::from_single_record(span, field),
+      Rule::env_pairs => EnvInstruction::from_pairs_record(span, field),
+      _ => Err(unexpected_token(field)),
+    }
   }
 
-  pub(crate) fn from_pairs_record(record: Pair) -> Result<EnvInstruction> {
+  fn from_pairs_record(span: Span, record: Pair) -> Result<EnvInstruction> {
     let mut vars = Vec::new();
 
     for field in record.into_inner() {
@@ -101,16 +101,19 @@ impl EnvInstruction {
       }
     }
 
-    Ok(EnvInstruction(vars))
+    Ok(EnvInstruction {
+      span,
+      vars,
+    })
   }
 
-  pub(crate) fn from_single_record(record: Pair) -> Result<EnvInstruction> {
+  fn from_single_record(span: Span, record: Pair) -> Result<EnvInstruction> {
     let mut key = None;
     let mut value = None;
 
     for field in record.into_inner() {
       match field.as_rule() {
-        Rule::env_name => key = Some(field.as_str()),
+        Rule::env_name => key = Some(parse_string(&field)?),
         Rule::env_single_value => value = Some(parse_any_breakable(field)?),
         Rule::env_single_quoted_value => {
           let v = unquote(field.as_str()).context(UnescapeError)?;
@@ -126,13 +129,20 @@ impl EnvInstruction {
 
     let key = key.ok_or_else(|| Error::GenericParseError {
       message: "env requires a key".into()
-    })?.to_string();
+    })?;
 
     let value = value.ok_or_else(|| Error::GenericParseError {
         message: "env requires a value".into()
     })?;
 
-    Ok(EnvInstruction(vec![EnvVar { key, value }]))
+    Ok(EnvInstruction {
+      span,
+      vars: vec![EnvVar {
+        span: Span::new(key.span.start, value.span.end),
+        key,
+        value,
+      }],
+    })
   }
 }
 
@@ -154,6 +164,7 @@ impl<'a> TryFrom<&'a Instruction> for &'a EnvInstruction {
 #[cfg(test)]
 mod tests {
   use indoc::indoc;
+  use pretty_assertions::assert_eq;
 
   use super::*;
   use crate::Dockerfile;
@@ -163,41 +174,125 @@ mod tests {
   fn env() -> Result<()> {
     assert_eq!(
       parse_single(r#"env foo=bar"#, Rule::env)?.into_env().unwrap(),
-      EnvInstruction(vec![EnvVar::new("foo", ((8, 11), "bar"))])
+      EnvInstruction {
+        span: Span::new(0, 11),
+        vars: vec![EnvVar::new(
+          Span::new(4, 11),
+          SpannedString {
+            span: Span::new(4, 7),
+            content: "foo".to_string(),
+          },
+          ((8, 11), "bar"),
+        )],
+      }
     );
 
     assert_eq!(
       parse_single(r#"env FOO_BAR="baz""#, Rule::env)?,
-      EnvInstruction(vec![EnvVar::new("FOO_BAR", ((12, 17), "baz"))]).into()
+      EnvInstruction {
+        span: Span::new(0, 17),
+        vars: vec![EnvVar::new(
+          Span::new(4, 17),
+          SpannedString {
+            span: Span::new(4, 11),
+            content: "FOO_BAR".to_string(),
+          },
+          ((12, 17), "baz"),
+        )],
+      }.into()
     );
 
     assert_eq!(
       parse_single(r#"env FOO_BAR "baz""#, Rule::env)?,
-      EnvInstruction(vec![EnvVar::new("FOO_BAR", ((12, 17), "baz"))]).into()
+      EnvInstruction {
+        span: Span::new(0, 17),
+        vars: vec![EnvVar::new(
+          Span::new(4, 17),
+          SpannedString {
+            span: Span::new(4, 11),
+            content: "FOO_BAR".to_string(),
+          },
+          ((12, 17), "baz")),
+        ],
+      }.into()
     );
 
     assert_eq!(
       parse_single(r#"env foo="bar\"baz""#, Rule::env)?,
-      EnvInstruction(vec![EnvVar::new("foo", ((8, 18), "bar\"baz"))]).into()
+      EnvInstruction {
+        span: Span::new(0, 18),
+        vars: vec![EnvVar::new(
+          Span::new(4, 18),
+          SpannedString {
+            span: Span::new(4, 7),
+            content: "foo".to_string(),
+          },
+          ((8, 18), "bar\"baz"),
+        )],
+      }.into()
     );
 
     assert_eq!(
       parse_single(r#"env foo='bar'"#, Rule::env)?,
-      EnvInstruction(vec![EnvVar::new("foo", ((8, 13), "bar"))]).into()
+      EnvInstruction {
+        span: Span::new(0, 13),
+        vars: vec![EnvVar::new(
+          Span::new(4, 13),
+          SpannedString {
+            span: Span::new(4, 7),
+            content: "foo".to_string(),
+          },
+          ((8, 13), "bar"),
+        )],
+      }.into()
     );
 
     assert_eq!(
       parse_single(r#"env foo='bar\'baz'"#, Rule::env)?,
-      EnvInstruction(vec![EnvVar::new("foo", ((8, 18), "bar'baz"))]).into()
+      EnvInstruction {
+        span: Span::new(0, 18),
+        vars: vec![EnvVar::new(
+          Span::new(4, 18),
+          SpannedString {
+            span: Span::new(4, 7),
+            content: "foo".to_string(),
+          },
+          ((8, 18), "bar'baz"),
+        )],
+      }.into()
     );
 
     assert_eq!(
       parse_single(r#"env foo="123" bar='456' baz=789"#, Rule::env)?,
-      EnvInstruction(vec![
-        EnvVar::new("foo", ((8, 13), "123")),
-        EnvVar::new("bar", ((18, 23), "456")),
-        EnvVar::new("baz", ((28, 31), "789")),
-      ]).into()
+      EnvInstruction {
+        span: Span::new(0, 31),
+        vars: vec![
+          EnvVar::new(
+            Span::new(4, 13),
+            SpannedString {
+              span: Span::new(4, 7),
+              content: "foo".to_string(),
+            },
+            ((8, 13), "123")
+          ),
+          EnvVar::new(
+            Span::new(14, 23),
+            SpannedString {
+              span: Span::new(14, 17),
+              content: "bar".to_string(),
+            },
+            ((18, 23), "456")
+          ),
+          EnvVar::new(
+            Span::new(24, 31),
+            SpannedString {
+              span: Span::new(24, 27),
+              content: "baz".to_string(),
+            },
+            ((28, 31), "789")
+          ),
+        ],
+      }.into()
     );
 
     assert!(Dockerfile::parse(r#"env foo="bar"bar"#).is_err());
@@ -218,11 +313,32 @@ mod tests {
 
         "#),
         Rule::env
-      )?.into_env().unwrap().0,
+      )?.into_env().unwrap().vars,
       vec![
-        EnvVar::new("foo", ((8, 9), "a")),
-        EnvVar::new("bar", ((18, 19), "b")),
-        EnvVar::new("baz", ((28, 29), "c"))
+        EnvVar::new(
+          Span::new(4, 9),
+          SpannedString {
+            span: Span::new(4, 7),
+            content: "foo".to_string(),
+          },
+          ((8, 9), "a")
+        ),
+        EnvVar::new(
+          Span::new(14, 19),
+          SpannedString {
+            span: Span::new(14, 17),
+            content: "bar".to_string(),
+          },
+          ((18, 19), "b")
+        ),
+        EnvVar::new(
+          Span::new(24, 29),
+          SpannedString {
+            span: Span::new(24, 27),
+            content: "baz".to_string(),
+          },
+          ((28, 29), "c")
+        )
       ]
     );
 
@@ -240,13 +356,19 @@ mod tests {
             labore et dolore magna aliqua.
         "#),
         Rule::env
-      )?.into_env().unwrap().0,
+      )?.into_env().unwrap().vars,
       vec![
-        EnvVar::new("foo", BreakableString::new((8, 143))
-          .add_string((8, 36), "Lorem ipsum dolor sit amet, ")
-          .add_string((38, 69), "  consectetur adipiscing elit, ")
-          .add_string((71, 109), "  sed do eiusmod tempor incididunt ut ")
-          .add_string((111, 143), "  labore et dolore magna aliqua.")
+        EnvVar::new(
+          Span::new(4, 143),
+          SpannedString {
+            span: Span::new(4, 7),
+            content: "foo".to_string(),
+          },
+          BreakableString::new((8, 143))
+            .add_string((8, 36), "Lorem ipsum dolor sit amet, ")
+            .add_string((38, 69), "  consectetur adipiscing elit, ")
+            .add_string((71, 109), "  sed do eiusmod tempor incididunt ut ")
+            .add_string((111, 143), "  labore et dolore magna aliqua.")
         )
       ]
     );
@@ -262,11 +384,17 @@ mod tests {
             consectetur adipiscing elit
         "#),
         Rule::env
-      )?.into_env().unwrap().0,
+      )?.into_env().unwrap().vars,
       vec![
-        EnvVar::new("foo", BreakableString::new((16, 75))
-          .add_string((16, 44), "Lorem ipsum dolor sit amet, ")
-          .add_string((46, 75), "  consectetur adipiscing elit")
+        EnvVar::new(
+          Span::new(8, 75),
+          SpannedString {
+            span: Span::new(8, 11),
+            content: "foo".to_string(),
+          },
+          BreakableString::new((16, 75))
+            .add_string((16, 44), "Lorem ipsum dolor sit amet, ")
+            .add_string((46, 75), "  consectetur adipiscing elit")
         )
       ]
     );
@@ -282,12 +410,18 @@ mod tests {
             consectetur adipiscing elit
         "#),
         Rule::env
-      )?.into_env().unwrap().0,
+      )?.into_env().unwrap().vars,
       vec![
-        EnvVar::new("foo", BreakableString::new((24, 91))
-          .add_string((24, 52), "Lorem ipsum dolor sit amet, ")
-          .add_comment((56, 61), "# baz")
-          .add_string((62, 91), "  consectetur adipiscing elit")
+        EnvVar::new(
+          Span::new(8, 91),
+          SpannedString {
+            span: Span::new(8, 11),
+            content: "foo".to_string(),
+          },
+          BreakableString::new((24, 91))
+            .add_string((24, 52), "Lorem ipsum dolor sit amet, ")
+            .add_comment((56, 61), "# baz")
+            .add_string((62, 91), "  consectetur adipiscing elit")
         )
       ]
     );

--- a/src/instructions/from.rs
+++ b/src/instructions/from.rs
@@ -49,7 +49,7 @@ impl FromInstruction {
       });
     };
 
-    let image_parsed = ImageRef::parse(&image.as_str());
+    let image_parsed = ImageRef::parse(&image.as_ref());
 
     let alias = if let Some(alias_field) = alias_field {
       Some(parse_string(&alias_field)?)

--- a/src/instructions/from.rs
+++ b/src/instructions/from.rs
@@ -5,6 +5,8 @@ use std::convert::TryFrom;
 use crate::dockerfile_parser::Instruction;
 use crate::image::ImageRef;
 use crate::parser::{Pair, Rule};
+use crate::parse_string;
+use crate::SpannedString;
 use crate::splicer::*;
 use crate::error::*;
 
@@ -17,13 +19,11 @@ use crate::error::*;
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct FromInstruction {
   pub span: Span,
-  pub image: String,
-  pub image_span: Span,
+  pub image: SpannedString,
   pub image_parsed: ImageRef,
 
   pub index: usize,
-  pub alias: Option<String>,
-  pub alias_span: Option<Span>
+  pub alias: Option<SpannedString>,
 }
 
 impl FromInstruction {
@@ -41,29 +41,26 @@ impl FromInstruction {
       };
     }
 
-    let (image, image_span) = if let Some(image_field) = image_field {
-      (image_field.as_str().to_string(), Span::from_pair(&image_field))
+    let image = if let Some(image_field) = image_field {
+      parse_string(&image_field)?
     } else {
       return Err(Error::GenericParseError {
         message: "missing from image".into()
       });
     };
 
-    let image_parsed = ImageRef::parse(&image);
+    let image_parsed = ImageRef::parse(&image.as_str());
 
-    let (alias, alias_span) = if let Some(alias_field) = alias_field {
-      (
-        Some(alias_field.as_str().to_string()),
-        Some(Span::from_pair(&alias_field))
-      )
+    let alias = if let Some(alias_field) = alias_field {
+      Some(parse_string(&alias_field)?)
     } else {
-      (None, None)
+      None
     };
 
     Ok(FromInstruction {
       span, index,
-      image, image_span, image_parsed,
-      alias, alias_span,
+      image, image_parsed,
+      alias,
     })
   }
 
@@ -91,6 +88,7 @@ impl<'a> TryFrom<&'a Instruction> for &'a FromInstruction {
 #[cfg(test)]
 mod tests {
   use indoc::indoc;
+  use pretty_assertions::assert_eq;
 
   use super::*;
   use crate::test_util::*;
@@ -108,8 +106,10 @@ mod tests {
     assert_eq!(from, FromInstruction {
       span: Span { start: 0, end: 16 },
       index: 0,
-      image: "alpine:3.10".into(),
-      image_span: Span { start: 5, end: 16 },
+      image: SpannedString {
+        span: Span { start: 5, end: 16 },
+        content: "alpine:3.10".into(),
+      },
       image_parsed: ImageRef {
         registry: None,
         image: "alpine".into(),
@@ -117,7 +117,6 @@ mod tests {
         hash: None
       },
       alias: None,
-      alias_span: None
     });
 
     Ok(())
@@ -167,16 +166,20 @@ mod tests {
     assert_eq!(from, FromInstruction {
       span: Span { start: 0, end: 68 },
       index: 0,
-      image: "alpine:3.10".into(),
-      image_span: Span { start: 17, end: 28 },
+      image: SpannedString {
+        span: Span { start: 17, end: 28 },
+        content: "alpine:3.10".into(),
+      },
       image_parsed: ImageRef {
         registry: None,
         image: "alpine".into(),
         tag: Some("3.10".into()),
         hash: None
       },
-      alias: Some("test".into()),
-      alias_span: Some((64, 68).into())
+      alias: Some(SpannedString {
+        span: (64, 68).into(),
+        content: "test".into(),
+      }),
     });
 
     Ok(())

--- a/src/splicer.rs
+++ b/src/splicer.rs
@@ -14,7 +14,7 @@ struct SpliceOffset {
 }
 
 /// A byte-index tuple representing a span of characters in a string
-#[derive(PartialEq, Eq, Clone, Ord, PartialOrd)]
+#[derive(PartialEq, Eq, Clone, Ord, PartialOrd, Copy)]
 pub struct Span {
   pub start: usize,
   pub end: usize
@@ -122,7 +122,7 @@ impl fmt::Debug for Span {
 /// };
 ///
 /// let mut splicer = dockerfile.splicer();
-/// splicer.splice(&from.image_span, "alpine:3.11");
+/// splicer.splice(&from.image.span, "alpine:3.11");
 ///
 /// assert_eq!(splicer.content, r#"
 ///   FROM alpine:3.11
@@ -197,7 +197,7 @@ mod tests {
 
     let first_from = TryInto::<&FromInstruction>::try_into(&d.instructions[0]).unwrap();
     assert_eq!(
-      first_from.alias_span.as_ref().unwrap().relative_span(&d),
+      first_from.alias.as_ref().unwrap().span.relative_span(&d),
       (0, (20, 25).into())
     );
 
@@ -229,7 +229,7 @@ mod tests {
 
     // build
     assert_eq!(
-      copy.flags[0].value_span.relative_span(&d),
+      copy.flags[0].value.span.relative_span(&d),
       (5, (12, 17).into())
     );
   }

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -130,7 +130,7 @@ impl<'a> Stages<'a> {
 
     for ins in &dockerfile.instructions {
       if let Instruction::From(from) = ins {
-        let image_name = from.image.as_str().to_ascii_lowercase();
+        let image_name = from.image.as_ref().to_ascii_lowercase();
         let parent = if image_name == "scratch" {
           StageParent::Scratch
         } else if let Some(stage) = stages.get_by_name(&image_name) {
@@ -147,7 +147,7 @@ impl<'a> Stages<'a> {
 
         stages.stages.push(Stage {
           index: next_stage_index,
-          name: from.alias.as_ref().map(|a| a.as_str().to_ascii_lowercase()),
+          name: from.alias.as_ref().map(|a| a.as_ref().to_ascii_lowercase()),
           instructions: vec![ins],
           parent,
           root

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -91,7 +91,7 @@ impl<'a> Stage<'a> {
       .iter()
       .enumerate()
       .find_map(|(i, ins)| match ins {
-        Instruction::Arg(a) => if a.name == name { Some(i) } else { None },
+        Instruction::Arg(a) => if a.name.content == name { Some(i) } else { None },
         _ => None
       })
   }
@@ -130,7 +130,7 @@ impl<'a> Stages<'a> {
 
     for ins in &dockerfile.instructions {
       if let Instruction::From(from) = ins {
-        let image_name = from.image.to_ascii_lowercase();
+        let image_name = from.image.as_str().to_ascii_lowercase();
         let parent = if image_name == "scratch" {
           StageParent::Scratch
         } else if let Some(stage) = stages.get_by_name(&image_name) {
@@ -147,7 +147,7 @@ impl<'a> Stages<'a> {
 
         stages.stages.push(Stage {
           index: next_stage_index,
-          name: from.alias.as_ref().map(|a| a.to_ascii_lowercase()),
+          name: from.alias.as_ref().map(|a| a.as_str().to_ascii_lowercase()),
           instructions: vec![ins],
           parent,
           root

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -9,10 +9,6 @@ use crate::dockerfile_parser::Instruction;
 use crate::error::*;
 use crate::parser::{DockerfileParser, Pair, Rule};
 
-pub fn strings(strs: &[&str]) -> Vec<String> {
-  strs.iter().map(|s| String::from(*s)).collect()
-}
-
 /// Parses a string into a single instruction using a particular syntax rule.
 ///
 /// This is technically over-constrained as we could just parse any single

--- a/src/util.rs
+++ b/src/util.rs
@@ -53,6 +53,7 @@ pub(crate) fn clean_escaped_breaks(s: &str) -> String {
   s.replace("\\\n", "")
 }
 
+/// A string that may be broken across many lines or an array of strings.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ShellOrExecExpr {
   Shell(BreakableString),
@@ -110,7 +111,7 @@ pub struct StringArray {
 
 impl StringArray {
   pub fn as_str_vec(&self) -> Vec<&str> {
-    self.elements.iter().map(|c| c.as_str()).collect()
+    self.elements.iter().map(|c| c.as_ref()).collect()
   }
 }
 
@@ -128,9 +129,15 @@ pub struct SpannedString {
   pub content: String,
 }
 
-impl SpannedString {
-  pub fn as_str(&self) -> &str {
-    self.content.as_str()
+impl AsRef<str> for SpannedString {
+  fn as_ref(&self) -> &str {
+    &self.content
+  }
+}
+
+impl fmt::Display for SpannedString {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    self.content.fmt(f)
   }
 }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,5 +1,0 @@
-// (C) Copyright 2019 Hewlett Packard Enterprise Development LP
-
-pub fn strings(strs: &[&str]) -> Vec<String> {
-  strs.iter().map(|s| String::from(*s)).collect()
-}


### PR DESCRIPTION
Several nodes in the tree were missing a span and there were a lot of `String` properties that would be better represented by `SpannedString`.

I'm making a code formatter using this crate (seems like a very good parser 🙂) and so knowing all the spans is very important.

Closes #16