### PR TITLE
allow `from` flags

### DIFF
--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -101,10 +101,13 @@ string_array = _{
   ) | "[" ~ arg_ws_maybe ~ "]"
 }
 
+from_flag_name = @{ ASCII_ALPHA+ }
+from_flag_value = @{ any_whitespace }
+from_flag = { "--" ~ from_flag_name ~ "=" ~ from_flag_value }
 from_image = @{ (ASCII_ALPHANUMERIC | "_" | "-" | "." | ":" | "/" | "$" | "{" | "}")+ }
 from_alias = { identifier_whitespace }
 from_alias_outer = _{ arg_ws ~ ^"as" ~ arg_ws ~ from_alias }
-from = { ^"from" ~ arg_ws ~ from_image ~ from_alias_outer?  }
+from = { ^"from" ~ (arg_ws ~ from_flag)* ~ arg_ws ~ from_image ~ from_alias_outer?  }
 
 arg_name = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 arg_value = ${ any_whitespace }


### PR DESCRIPTION
From flags, such as `FROM --platform=linux/amd64 node:lts-alpine` fail in dprint.  This tweak allows those flags.

(it copies the flags from the copy_flags, can see just having generic flags, unless specific flags are matched against.)