### PR TITLE
Add support for heredocs syntax

### DIFF
--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -83,7 +83,7 @@ any_breakable = ${
 any_eol = _{ (!NEWLINE ~ ANY)* }
 
 // consumes all characters until the next whitespace
-any_whitespace = _{ (!(NEWLINE | EOI | arg_ws) ~ ANY)+ }
+any_whitespace = _{ (!(NEWLINE | EOI | arg_ws | heredoc_op) ~ ANY)+ }
 
 // consumes identifier characters until the next whitespace
 identifier_whitespace = _{ (!ws ~ (ASCII_ALPHANUMERIC | "_" | "-"))+ }
@@ -103,10 +103,9 @@ string_array = _{
 }
 
 heredoc_op = _{ "<<" | "<<-" }
-heredoc_delim = _{ ASCII_ALPHA+ }
+heredoc_delim = _{ (ASCII_ALPHANUMERIC | "_" | "-" | "." | "/")+ }
 heredoc_terminator = _{ heredoc_delim ~ NEWLINE }
-heredoc_body = { (!heredoc_terminator ~ any_content ~ NEWLINE?)* }
-heredoc = _{ heredoc_op ~ heredoc_delim ~ NEWLINE ~ heredoc_body ~ heredoc_terminator }
+heredoc_body = @{ (!heredoc_terminator ~ ANY)* }
 
 from_flag_name = @{ ASCII_ALPHA+ }
 from_flag_value = @{ any_whitespace }
@@ -135,7 +134,7 @@ label = { ^"label" ~ (label_single | (arg_ws ~ label_pair?)+) }
 
 run_shell = @{ any_breakable }
 run_exec = { string_array }
-run_heredoc = { heredoc }
+run_heredoc = { heredoc_op ~ heredoc_delim ~ NEWLINE ~ heredoc_body ~ heredoc_terminator }
 run = { ^"run" ~ arg_ws ~ (run_exec | run_shell | run_heredoc) }
 
 entrypoint_shell = @{ any_breakable }
@@ -150,8 +149,15 @@ copy_flag_name = @{ ASCII_ALPHA+ }
 copy_flag_value = @{ any_whitespace }
 copy_flag = { "--" ~ copy_flag_name ~ "=" ~ copy_flag_value }
 copy_pathspec = @{ any_whitespace }
-copy_heredoc = { heredoc }
-copy = { ^"copy" ~ (((arg_ws ~ copy_flag)* ~ (arg_ws ~ copy_pathspec){2,}) | copy_heredoc) }
+copy_standard = { (arg_ws ~ copy_flag)* ~ (arg_ws ~ copy_pathspec){2,} }
+copy_heredoc = {
+  (arg_ws ~ copy_flag)* ~
+  (arg_ws ~ heredoc_op ~ heredoc_delim)+ ~
+  (arg_ws ~ copy_pathspec) ~
+  NEWLINE ~
+  (heredoc_body ~ heredoc_terminator)+
+}
+copy = { ^"copy" ~ ( copy_heredoc |copy_standard) }
 
 env_name = ${ (ASCII_ALPHANUMERIC | "_")+ }
 env_pair_value = ${ any_whitespace }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -75,7 +75,7 @@ any_breakable = ${
   ) | (
     // ... OR some piece of content, requiring a continuation EXCEPT on the
     // final line
-    any_content ~ (line_continuation ~ any_breakable)?
+    !run_heredoc ~ any_content ~ (line_continuation ~ any_breakable)?
   )
 }
 
@@ -102,7 +102,7 @@ string_array = _{
   ) | "[" ~ arg_ws_maybe ~ "]"
 }
 
-heredoc_op = _{ "<<" | "<<-" }
+heredoc_op = _{ "<<" }
 heredoc_delim = _{ (ASCII_ALPHANUMERIC | "_" | "-" | "." | "/")+ }
 heredoc_terminator = _{ heredoc_delim ~ NEWLINE }
 heredoc_body = @{ (!heredoc_terminator ~ ANY)* }
@@ -132,10 +132,10 @@ label_single_quoted_name = { string }
 label_single = { arg_ws ~ (label_single_quoted_name | label_single_name) ~ arg_ws ~ (label_quoted_value | label_value) }
 label = { ^"label" ~ (label_single | (arg_ws ~ label_pair?)+) }
 
-run_shell = @{ any_breakable }
-run_exec = { string_array }
 run_heredoc = { heredoc_op ~ heredoc_delim ~ NEWLINE ~ heredoc_body ~ heredoc_terminator }
-run = { ^"run" ~ arg_ws ~ (run_exec | run_shell | run_heredoc) }
+run_shell = { run_heredoc | (any_breakable ~ run_heredoc) | any_breakable }
+run_exec = { string_array }
+run = { ^"run" ~ arg_ws ~ (run_exec | run_shell) }
 
 entrypoint_shell = @{ any_breakable }
 entrypoint_exec = { string_array }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -64,6 +64,7 @@ any_content = @{
   (
     !NEWLINE ~
     !line_continuation ~
+    !heredoc_op ~
     ANY
   )+
 }
@@ -101,6 +102,12 @@ string_array = _{
   ) | "[" ~ arg_ws_maybe ~ "]"
 }
 
+heredoc_op = _{ "<<" | "<<-" }
+heredoc_delim = _{ ASCII_ALPHA+ }
+heredoc_terminator = _{ heredoc_delim ~ NEWLINE }
+heredoc_body = { (!heredoc_terminator ~ any_content ~ NEWLINE?)* }
+heredoc = _{ heredoc_op ~ heredoc_delim ~ NEWLINE ~ heredoc_body ~ heredoc_terminator }
+
 from_flag_name = @{ ASCII_ALPHA+ }
 from_flag_value = @{ any_whitespace }
 from_flag = { "--" ~ from_flag_name ~ "=" ~ from_flag_value }
@@ -128,7 +135,8 @@ label = { ^"label" ~ (label_single | (arg_ws ~ label_pair?)+) }
 
 run_shell = @{ any_breakable }
 run_exec = { string_array }
-run = { ^"run" ~ arg_ws ~ (run_exec | run_shell) }
+run_heredoc = { heredoc }
+run = { ^"run" ~ arg_ws ~ (run_exec | run_shell | run_heredoc) }
 
 entrypoint_shell = @{ any_breakable }
 entrypoint_exec = { string_array }
@@ -142,7 +150,8 @@ copy_flag_name = @{ ASCII_ALPHA+ }
 copy_flag_value = @{ any_whitespace }
 copy_flag = { "--" ~ copy_flag_name ~ "=" ~ copy_flag_value }
 copy_pathspec = @{ any_whitespace }
-copy = { ^"copy" ~ (arg_ws ~ copy_flag)* ~ (arg_ws ~ copy_pathspec){2,} }
+copy_heredoc = { heredoc }
+copy = { ^"copy" ~ (((arg_ws ~ copy_flag)* ~ (arg_ws ~ copy_pathspec){2,}) | copy_heredoc) }
 
 env_name = ${ (ASCII_ALPHANUMERIC | "_")+ }
 env_pair_value = ${ any_whitespace }

--- a/src/instructions/copy.rs
+++ b/src/instructions/copy.rs
@@ -70,6 +70,7 @@ impl CopyInstruction {
         Rule::copy_flag => flags.push(CopyFlag::from_record(field)?),
         Rule::copy_pathspec => paths.push(parse_string(&field)?),
         Rule::comment => continue,
+        // Rule::heredoc => 
         _ => return Err(unexpected_token(field))
       }
     }

--- a/src/instructions/copy.rs
+++ b/src/instructions/copy.rs
@@ -353,4 +353,74 @@ mod tests {
 
     Ok(())
   }
+
+  #[test]
+  fn copy_multi_heredoc() -> Result<()> {
+    assert_eq!(
+      parse_single(
+        indoc!(r#"
+          COPY <<EOF <<EOF2 /usr/share/nginx/html/index.html
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>Welcome to nginx!</title>
+          </head>
+          <body>
+              <h1>Welcome to nginx!</h1>
+          </body>
+          </html>
+          EOF
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>Welcome to nginx!</title>
+          </head>
+          <body>
+              <h1>Welcome to nginx!</h1>
+          </body>
+          </html>
+          EOF2
+        "#),
+        Rule::copy
+      )?.into_copy().unwrap(),
+      CopyInstruction {
+        span: Span { start: 0, end: 318 },
+        flags: vec![],
+        sources: vec![SourceType::FileContent(SpannedString {
+          span: Span::new(51, 180),
+          content: indoc!(r#"
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>Welcome to nginx!</title>
+          </head>
+          <body>
+              <h1>Welcome to nginx!</h1>
+          </body>
+          </html>
+          "#).to_string(),
+        }), 
+        SourceType::FileContent(SpannedString {
+          span: Span::new(184, 313),
+          content: indoc!(r#"
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>Welcome to nginx!</title>
+          </head>
+          <body>
+              <h1>Welcome to nginx!</h1>
+          </body>
+          </html>
+          "#).to_string(),
+        })],
+        destination: SpannedString {
+          span: Span::new(18, 50),
+          content: "/usr/share/nginx/html/index.html".to_string(),
+        },
+      }.into()
+    );
+
+    Ok(())
+  }
 }

--- a/src/instructions/run.rs
+++ b/src/instructions/run.rs
@@ -34,7 +34,11 @@ impl RunInstruction {
         span,
         expr: ShellOrExecExpr::Shell(parse_any_breakable(field)?),
       }),
-      _ => Err(unexpected_token(field)),
+      Rule::run_heredoc => Ok(RunInstruction {
+        span,
+        expr: ShellOrExecExpr::Heredoc(parse_heredoc(field)?)
+      }),
+      _ => Err(unexpected_token(field))
     }
   }
 
@@ -273,6 +277,27 @@ mod tests {
             content: "hello world".to_string(),
           }],
         })
+      }.into()
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn run_heredoc() -> Result<()> {
+    assert_eq!(
+      parse_single(indoc!(r#"RUN <<EOF
+        echo "hello world"
+        EOF
+      "#), Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 33),
+        expr: ShellOrExecExpr::Heredoc(Heredoc {
+          span: Span::new(4, 33),
+          // operator: "<<".to_string(),
+          // delimiter: "EOF".to_string(),
+          commands: vec!["echo \"hello world\"".to_string()],
+        }),
       }.into()
     );
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -283,17 +283,11 @@ pub(crate) fn parse_any_breakable(pair: Pair) -> Result<BreakableString> {
 
 pub struct Heredoc {
   pub span: Span,
-  // pub operator: String,
-  // pub delimiter: String,
   pub commands: Vec<String>,
 }
 
-// impl 
-
 pub(crate) fn parse_heredoc(record: Pair) -> Result<Heredoc> {
   let span = Span::from_pair(&record);
-  // let mut operator = None;
-  // let mut delimiter = None;
   let mut commands = Vec::new();
 
   for field in record.into_inner() {
@@ -310,8 +304,6 @@ pub(crate) fn parse_heredoc(record: Pair) -> Result<Heredoc> {
 
   Ok(Heredoc {
     span,
-    // operator: operator.ok_or_else(|| Error::GenericParseError { message: "heredoc operator is required".into() })?,
-    // delimiter: delimiter.ok_or_else(|| Error::GenericParseError { message: "heredoc delimiter is required".into() })?,
     commands,
   })
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -58,6 +58,7 @@ pub(crate) fn clean_escaped_breaks(s: &str) -> String {
 pub enum ShellOrExecExpr {
   Shell(BreakableString),
   Exec(StringArray),
+  Heredoc(Heredoc),
 }
 
 impl ShellOrExecExpr {
@@ -274,5 +275,43 @@ pub(crate) fn parse_any_breakable(pair: Pair) -> Result<BreakableString> {
   Ok(BreakableString {
     span: (&pair).into(),
     components: parse_any_breakable_inner(pair)?,
+  })
+}
+
+/// A heredoc expression
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
+
+pub struct Heredoc {
+  pub span: Span,
+  // pub operator: String,
+  // pub delimiter: String,
+  pub commands: Vec<String>,
+}
+
+// impl 
+
+pub(crate) fn parse_heredoc(record: Pair) -> Result<Heredoc> {
+  let span = Span::from_pair(&record);
+  // let mut operator = None;
+  // let mut delimiter = None;
+  let mut commands = Vec::new();
+
+  for field in record.into_inner() {
+    match field.as_rule() {
+      Rule::heredoc_body => {
+        let content = field.as_str().to_string();
+        commands = content.lines().map(String::from).collect();
+      }
+      _ => return {
+        Err(unexpected_token(field))
+      }
+    }
+  }
+
+  Ok(Heredoc {
+    span,
+    // operator: operator.ok_or_else(|| Error::GenericParseError { message: "heredoc operator is required".into() })?,
+    // delimiter: delimiter.ok_or_else(|| Error::GenericParseError { message: "heredoc delimiter is required".into() })?,
+    commands,
   })
 }


### PR DESCRIPTION
Add support for heredocs in run and copy instructions. Addresses #37 

**Run example:**
```
RUN <<EOF
echo "hello world"
EOF
```
The heredoc:
```
<<EOF
echo "hello world"
EOF
```
gets parsed into a `Heredoc` struct, with `content` being the entire heredoc as a string.

**Copy example:**
```
COPY <<EOF /usr/share/nginx/html/index.html
(your index page goes here)
EOF
```
The heredoc:
```
<<EOF /usr/share/nginx/html/index.html
(your index page goes here)
EOF
```
gets parsed into a `CopyInstruction` with : 
- `destination` as `/usr/share/nginx/html/index.html`
- `sources` as a vector of file contents, in this case the single element is `(your index page goes here)`
- other fields are same as non-heredoc syntax

Multi-heredoc copy instructions are also supported:
```
COPY <<robots.txt <<humans.txt /usr/share/nginx/html/
(robots content)
robots.txt
(humans content)
humans.txt
```
The heredoc:
```
<<robots.txt <<humans.txt /usr/share/nginx/html/
(robots content)
robots.txt
(humans content)
humans.txt
```
gets parsed into a `CopyInstruction` with : 
- `destination` as `/usr/share/nginx/html/`
- `sources` as a vector of file contents, in this case the two elements are `(robots content)` and `(humans content)`
- other fields are same as non-heredoc syntax