### PR TITLE
Akshay/run heredoc quoted and dash

### DIFF
--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -139,12 +139,13 @@ run_heredoc = { heredoc_op ~ arg_ws_maybe ~ heredoc_delim ~ any_eol ~ NEWLINE ~ 
 run_shell = { run_heredoc | (any_breakable ~ run_heredoc) | any_breakable }
 run_exec = { string_array }
 
-// RUN flags (BuildKit options): --device, --mount, --network, --security
-run_flag_name = @{ ASCII_ALPHA+ }
-run_flag_value = @{ any_whitespace }
-run_flag = { "--" ~ run_flag_name ~ "=" ~ run_flag_value }
+// RUN options (BuildKit options): --device, --mount, --network, --security
+// See: https://docs.docker.com/reference/dockerfile/#run
+run_option_name = @{ ASCII_ALPHA+ }
+run_option_value = @{ any_whitespace }
+run_option = { "--" ~ run_option_name ~ "=" ~ run_option_value }
 
-run = { ^"run" ~ (arg_ws ~ run_flag)* ~ arg_ws ~ (run_exec | run_shell) }
+run = { ^"run" ~ (arg_ws ~ run_option)* ~ arg_ws ~ (run_exec | run_shell) }
 
 entrypoint_shell = @{ any_breakable }
 entrypoint_exec = { string_array }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -138,7 +138,13 @@ label = { ^"label" ~ (label_single | (arg_ws ~ label_pair?)+) }
 run_heredoc = { heredoc_op ~ arg_ws_maybe ~ heredoc_delim ~ any_eol ~ NEWLINE ~ heredoc_body ~ heredoc_terminator }
 run_shell = { run_heredoc | (any_breakable ~ run_heredoc) | any_breakable }
 run_exec = { string_array }
-run = { ^"run" ~ arg_ws ~ (run_exec | run_shell) }
+
+// RUN flags (BuildKit options): --device, --mount, --network, --security
+run_flag_name = @{ ASCII_ALPHA+ }
+run_flag_value = @{ any_whitespace }
+run_flag = { "--" ~ run_flag_name ~ "=" ~ run_flag_value }
+
+run = { ^"run" ~ (arg_ws ~ run_flag)* ~ arg_ws ~ (run_exec | run_shell) }
 
 entrypoint_shell = @{ any_breakable }
 entrypoint_exec = { string_array }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -83,7 +83,7 @@ any_breakable = ${
 any_eol = _{ (!NEWLINE ~ ANY)* }
 
 // consumes all characters until the next whitespace
-any_whitespace = _{ (!(NEWLINE | EOI | arg_ws) ~ ANY)+ }
+any_whitespace = _{ (!(NEWLINE | EOI | arg_ws | heredoc_op) ~ ANY)+ }
 
 // consumes identifier characters until the next whitespace
 identifier_whitespace = _{ (!ws ~ (ASCII_ALPHANUMERIC | "_" | "-"))+ }
@@ -103,10 +103,9 @@ string_array = _{
 }
 
 heredoc_op = _{ "<<" | "<<-" }
-heredoc_delim = _{ ASCII_ALPHA+ }
+heredoc_delim = _{ (ASCII_ALPHANUMERIC | "_" | "-" | "." | "/")+ }
 heredoc_terminator = _{ heredoc_delim ~ NEWLINE }
-heredoc_body = { (!heredoc_terminator ~ any_content ~ NEWLINE?)* }
-heredoc = _{ heredoc_op ~ heredoc_delim ~ NEWLINE ~ heredoc_body ~ heredoc_terminator }
+heredoc_body = @{ (!heredoc_terminator ~ ANY)* }
 
 from_flag_name = @{ ASCII_ALPHA+ }
 from_flag_value = @{ any_whitespace }
@@ -135,7 +134,7 @@ label = { ^"label" ~ (label_single | (arg_ws ~ label_pair?)+) }
 
 run_shell = @{ any_breakable }
 run_exec = { string_array }
-run_heredoc = { heredoc }
+run_heredoc = { heredoc_op ~ heredoc_delim ~ NEWLINE ~ heredoc_body ~ heredoc_terminator }
 run = { ^"run" ~ arg_ws ~ (run_exec | run_shell | run_heredoc) }
 
 entrypoint_shell = @{ any_breakable }
@@ -150,8 +149,15 @@ copy_flag_name = @{ ASCII_ALPHA+ }
 copy_flag_value = @{ any_whitespace }
 copy_flag = { "--" ~ copy_flag_name ~ "=" ~ copy_flag_value }
 copy_pathspec = @{ any_whitespace }
-copy_heredoc = { heredoc }
-copy = { ^"copy" ~ (((arg_ws ~ copy_flag)* ~ (arg_ws ~ copy_pathspec){2,}) | copy_heredoc) }
+copy_standard = { (arg_ws ~ copy_flag)* ~ (arg_ws ~ copy_pathspec){2,} }
+copy_heredoc = {
+  (arg_ws ~ copy_flag)* ~
+  (arg_ws ~ heredoc_op ~ heredoc_delim)+ ~
+  (arg_ws ~ copy_pathspec) ~
+  NEWLINE ~
+  (heredoc_body ~ heredoc_terminator)+
+}
+copy = { ^"copy" ~ ( copy_heredoc |copy_standard) }
 
 env_name = ${ (ASCII_ALPHANUMERIC | "_")+ }
 env_pair_value = ${ any_whitespace }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -75,7 +75,7 @@ any_breakable = ${
   ) | (
     // ... OR some piece of content, requiring a continuation EXCEPT on the
     // final line
-    any_content ~ (line_continuation ~ any_breakable)?
+    !run_heredoc ~ any_content ~ (line_continuation ~ any_breakable)?
   )
 }
 
@@ -102,7 +102,7 @@ string_array = _{
   ) | "[" ~ arg_ws_maybe ~ "]"
 }
 
-heredoc_op = _{ "<<" | "<<-" }
+heredoc_op = _{ "<<" }
 heredoc_delim = _{ (ASCII_ALPHANUMERIC | "_" | "-" | "." | "/")+ }
 heredoc_terminator = _{ heredoc_delim ~ NEWLINE }
 heredoc_body = @{ (!heredoc_terminator ~ ANY)* }
@@ -132,10 +132,10 @@ label_single_quoted_name = { string }
 label_single = { arg_ws ~ (label_single_quoted_name | label_single_name) ~ arg_ws ~ (label_quoted_value | label_value) }
 label = { ^"label" ~ (label_single | (arg_ws ~ label_pair?)+) }
 
-run_shell = @{ any_breakable }
-run_exec = { string_array }
 run_heredoc = { heredoc_op ~ heredoc_delim ~ NEWLINE ~ heredoc_body ~ heredoc_terminator }
-run = { ^"run" ~ arg_ws ~ (run_exec | run_shell | run_heredoc) }
+run_shell = { run_heredoc | (any_breakable ~ run_heredoc) | any_breakable }
+run_exec = { string_array }
+run = { ^"run" ~ arg_ws ~ (run_exec | run_shell) }
 
 entrypoint_shell = @{ any_breakable }
 entrypoint_exec = { string_array }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -59,7 +59,7 @@ arg_ws_maybe = _{ (ws | line_continuation ~ (comment_line | empty_line)*)* }
 // continues consuming input beyond a newline, if the newline is preceeded by an
 // escape (\)
 // these tokens need to be preserved in the final tree so they can be handled
-// appropraitely; pest's ignore rules aren't sufficient for our needs
+// appropriately; pest's ignore rules aren't sufficient for our needs
 any_content = @{
   (
     !NEWLINE ~
@@ -72,6 +72,9 @@ any_breakable = ${
   (
     // can be any comment string (no line continuation required)
     comment_line ~ any_breakable?
+  ) | (
+    // allow a leading line continuation before any content or comments
+    line_continuation ~ any_breakable
   ) | (
     // ... OR some piece of content, requiring a continuation EXCEPT on the
     // final line
@@ -145,6 +148,7 @@ run_option_name = @{ ASCII_ALPHA+ }
 run_option_value = @{ any_whitespace }
 run_option = { "--" ~ run_option_name ~ "=" ~ run_option_value }
 
+// run = { ^"run" ~ ( (arg_ws ~ run_exec) | (ws+ ~ run_shell) ) }
 run = { ^"run" ~ (arg_ws ~ run_option)* ~ arg_ws ~ (run_exec | run_shell) }
 
 entrypoint_shell = @{ any_breakable }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -105,7 +105,8 @@ string_array = _{
 heredoc_op = _{ "<<" }
 heredoc_delim = { (ASCII_ALPHANUMERIC | "_" | "-" | "." | "/")+ }
 heredoc_terminator = { heredoc_delim ~ NEWLINE }
-heredoc_body = @{ (!heredoc_terminator ~ ANY)* }
+heredoc_line = @{ !(heredoc_delim ~ NEWLINE) ~ (!NEWLINE ~ ANY)* ~ NEWLINE }
+heredoc_body = @{ heredoc_line* }
 
 from_flag_name = @{ ASCII_ALPHA+ }
 from_flag_value = @{ any_whitespace }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -103,9 +103,11 @@ string_array = _{
 }
 
 heredoc_op = _{ "<<" }
-heredoc_delim = { (ASCII_ALPHANUMERIC | "_" | "-" | "." | "/")+ }
-heredoc_terminator = { heredoc_delim ~ NEWLINE }
-heredoc_line = @{ !(heredoc_delim ~ NEWLINE) ~ (!NEWLINE ~ ANY)* ~ NEWLINE }
+heredoc_delim_str = _{ (ASCII_ALPHANUMERIC | "_" | "-" | "." | "/")+ }
+
+heredoc_delim = _{ PUSH(heredoc_delim_str) }
+heredoc_terminator = _{ PEEK[0..1] }
+heredoc_line = @{ !(heredoc_terminator) ~ any_eol ~ NEWLINE }
 heredoc_body = @{ heredoc_line* }
 
 from_flag_name = @{ ASCII_ALPHA+ }
@@ -133,7 +135,7 @@ label_single_quoted_name = { string }
 label_single = { arg_ws ~ (label_single_quoted_name | label_single_name) ~ arg_ws ~ (label_quoted_value | label_value) }
 label = { ^"label" ~ (label_single | (arg_ws ~ label_pair?)+) }
 
-run_heredoc = { heredoc_op ~ heredoc_delim ~ NEWLINE ~ heredoc_body ~ heredoc_terminator }
+run_heredoc = { heredoc_op ~ arg_ws_maybe ~ heredoc_delim ~ any_eol ~ NEWLINE ~ heredoc_body ~ heredoc_terminator }
 run_shell = { run_heredoc | (any_breakable ~ run_heredoc) | any_breakable }
 run_exec = { string_array }
 run = { ^"run" ~ arg_ws ~ (run_exec | run_shell) }
@@ -153,10 +155,10 @@ copy_pathspec = @{ any_whitespace }
 copy_standard = { (arg_ws ~ copy_flag)* ~ (arg_ws ~ copy_pathspec){2,} }
 copy_heredoc = {
   (arg_ws ~ copy_flag)* ~
-  (arg_ws ~ heredoc_op ~ heredoc_delim)+ ~
+  (arg_ws ~ heredoc_op ~ arg_ws_maybe ~ heredoc_delim) ~
   (arg_ws ~ copy_pathspec) ~
-  NEWLINE ~
-  (heredoc_body ~ heredoc_terminator)+
+  arg_ws_maybe ~ NEWLINE ~
+  (heredoc_body ~ heredoc_terminator)
 }
 copy = { ^"copy" ~ ( copy_heredoc |copy_standard) }
 

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -64,7 +64,7 @@ any_content = @{
   (
     !NEWLINE ~
     !line_continuation ~
-    !heredoc_op ~
+    !run_heredoc ~
     ANY
   )+
 }
@@ -75,7 +75,7 @@ any_breakable = ${
   ) | (
     // ... OR some piece of content, requiring a continuation EXCEPT on the
     // final line
-    !run_heredoc ~ any_content ~ (line_continuation ~ any_breakable)?
+    any_content ~ (line_continuation ~ any_breakable)?
   )
 }
 

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -64,6 +64,7 @@ any_content = @{
   (
     !NEWLINE ~
     !line_continuation ~
+    !heredoc_op ~
     ANY
   )+
 }
@@ -101,6 +102,12 @@ string_array = _{
   ) | "[" ~ arg_ws_maybe ~ "]"
 }
 
+heredoc_op = _{ "<<" | "<<-" }
+heredoc_delim = _{ ASCII_ALPHA+ }
+heredoc_terminator = _{ heredoc_delim ~ NEWLINE }
+heredoc_body = { (!heredoc_terminator ~ any_content ~ NEWLINE?)* }
+heredoc = _{ heredoc_op ~ heredoc_delim ~ NEWLINE ~ heredoc_body ~ heredoc_terminator }
+
 from_flag_name = @{ ASCII_ALPHA+ }
 from_flag_value = @{ any_whitespace }
 from_flag = { "--" ~ from_flag_name ~ "=" ~ from_flag_value }
@@ -128,7 +135,8 @@ label = { ^"label" ~ (label_single | (arg_ws ~ label_pair?)+) }
 
 run_shell = @{ any_breakable }
 run_exec = { string_array }
-run = { ^"run" ~ arg_ws ~ (run_exec | run_shell) }
+run_heredoc = { heredoc }
+run = { ^"run" ~ arg_ws ~ (run_exec | run_shell | run_heredoc) }
 
 entrypoint_shell = @{ any_breakable }
 entrypoint_exec = { string_array }
@@ -142,7 +150,8 @@ copy_flag_name = @{ ASCII_ALPHA+ }
 copy_flag_value = @{ any_whitespace }
 copy_flag = { "--" ~ copy_flag_name ~ "=" ~ copy_flag_value }
 copy_pathspec = @{ any_whitespace }
-copy = { ^"copy" ~ (arg_ws ~ copy_flag)* ~ (arg_ws ~ copy_pathspec){2,} }
+copy_heredoc = { heredoc }
+copy = { ^"copy" ~ (((arg_ws ~ copy_flag)* ~ (arg_ws ~ copy_pathspec){2,}) | copy_heredoc) }
 
 env_name = ${ (ASCII_ALPHANUMERIC | "_")+ }
 env_pair_value = ${ any_whitespace }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -148,8 +148,7 @@ run_option_name = @{ ASCII_ALPHA+ }
 run_option_value = @{ any_whitespace }
 run_option = { "--" ~ run_option_name ~ "=" ~ run_option_value }
 
-// run = { ^"run" ~ ( (arg_ws ~ run_exec) | (ws+ ~ run_shell) ) }
-run = { ^"run" ~ (arg_ws ~ run_option)* ~ arg_ws ~ (run_exec | run_shell) }
+run = { ^"run" ~ (arg_ws ~ run_option)* ~ ( (arg_ws ~ run_exec) | (ws+ ~ run_shell) ) }
 
 entrypoint_shell = @{ any_breakable }
 entrypoint_exec = { string_array }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -103,8 +103,8 @@ string_array = _{
 }
 
 heredoc_op = _{ "<<" }
-heredoc_delim = _{ (ASCII_ALPHANUMERIC | "_" | "-" | "." | "/")+ }
-heredoc_terminator = _{ heredoc_delim ~ NEWLINE }
+heredoc_delim = { (ASCII_ALPHANUMERIC | "_" | "-" | "." | "/")+ }
+heredoc_terminator = { heredoc_delim ~ NEWLINE }
 heredoc_body = @{ (!heredoc_terminator ~ ANY)* }
 
 from_flag_name = @{ ASCII_ALPHA+ }

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -106,7 +106,7 @@ heredoc_op = _{ "<<" }
 heredoc_delim_str = _{ (ASCII_ALPHANUMERIC | "_" | "-" | "." | "/")+ }
 
 heredoc_delim = _{ PUSH(heredoc_delim_str) }
-heredoc_terminator = _{ PEEK[0..1] }
+heredoc_terminator = _{ POP }
 heredoc_line = @{ !(heredoc_terminator) ~ any_eol ~ NEWLINE }
 heredoc_body = @{ heredoc_line* }
 

--- a/src/dockerfile_parser.pest
+++ b/src/dockerfile_parser.pest
@@ -105,11 +105,19 @@ string_array = _{
   ) | "[" ~ arg_ws_maybe ~ "]"
 }
 
-heredoc_op = _{ "<<" }
+// "<<" or "<<-" (dash variant strips leading tabs from body and terminator)
+heredoc_op = _{ "<<" ~ "-"? }
 heredoc_delim_str = _{ (ASCII_ALPHANUMERIC | "_" | "-" | "." | "/")+ }
 
-heredoc_delim = _{ PUSH(heredoc_delim_str) }
-heredoc_terminator = _{ POP }
+// allow optional surrounding ' or " on the open form; the PUSHed token is
+// always the unquoted name, so the terminator matches `EOF` not `'EOF'`
+heredoc_delim = _{
+    ("'" ~ PUSH(heredoc_delim_str) ~ "'")
+  | ("\"" ~ PUSH(heredoc_delim_str) ~ "\"")
+  | PUSH(heredoc_delim_str)
+}
+// terminator: optional leading tabs (for <<- support) then the POPped name
+heredoc_terminator = _{ "\t"* ~ POP }
 heredoc_line = @{ !(heredoc_terminator) ~ any_eol ~ NEWLINE }
 heredoc_body = @{ heredoc_line* }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -99,10 +99,16 @@ impl ImageRef {
   /// This is not fallible, however malformed image strings may return
   /// unexpected results.
   pub fn parse(s: &str) -> ImageRef {
-    // tags may be one of:
+
+    // Refs are of the form [HOST[:PORT]/]NAMESPACE/REPOSITORY[:TAG][@DIGEST]
+
+    // Examples of tags:
     // foo (implies registry.hub.docker.com/library/foo:latest)
     // foo:bar (implies registry.hub.docker.com/library/foo:bar)
     // org/foo:bar (implies registry.hub.docker.com/org/foo:bar)
+
+    // It's possible for a ref to include both a tag and a digest, in which case the tag must be parsed out. 
+    // e.g. nvidia/cuda:latest@sha256:2d913b09e6be8387e1a10976933642c73c840c0b735f0bf3c28d97fc9bc422e0
 
     // per https://stackoverflow.com/a/42116190, some extra rules are needed to
     // disambiguate external registries
@@ -127,7 +133,7 @@ impl ImageRef {
       // parts length is guaranteed to be at least 1 given an empty string
       let (image, hash) = image_full.split_at(at_pos);
 
-      // extract the tag if present
+      // Parse the tag in the case of a tag and digest hash
       let (image, tag) = image
         .split_once(':')
         .map(|(img, t)| (img, Some(t.to_string())))

--- a/src/image.rs
+++ b/src/image.rs
@@ -127,11 +127,18 @@ impl ImageRef {
       // parts length is guaranteed to be at least 1 given an empty string
       let (image, hash) = image_full.split_at(at_pos);
 
+      let (image, tag) = if let Some(colon_pos) = image.find(':') {
+        let (image_no_tag, tag) = image.split_at(colon_pos);
+        (image_no_tag, Some(tag[1..].to_string()))
+      } else {
+        (image, None)
+      };
+
       ImageRef {
         registry,
         image: image.to_string(),
         hash: Some(hash[1..].to_string()),
-        tag: None
+        tag,
       }
     } else {
       // parts length is guaranteed to be at least 1 given an empty string

--- a/src/instructions/copy.rs
+++ b/src/instructions/copy.rs
@@ -110,7 +110,7 @@ impl CopyInstruction {
           match inner.as_rule() {
             Rule::heredoc_delim => delimiters.push(parse_string(&inner)?),
             Rule::copy_flag => flags.push(CopyFlag::from_record(inner)?),
-            Rule::copy_pathspec => destination = (parse_string(&inner)?),
+            Rule::copy_pathspec => destination = parse_string(&inner)?,
             Rule::heredoc_body => sources.push(parse_string(&inner)?),
             Rule::heredoc_terminator => terminators.push(parse_string(&inner)?),
             _ => return Err(unexpected_token(inner))

--- a/src/instructions/copy.rs
+++ b/src/instructions/copy.rs
@@ -70,6 +70,7 @@ impl CopyInstruction {
         Rule::copy_flag => flags.push(CopyFlag::from_record(field)?),
         Rule::copy_pathspec => paths.push(parse_string(&field)?),
         Rule::comment => continue,
+        // Rule::heredoc => 
         _ => return Err(unexpected_token(field))
       }
     }

--- a/src/instructions/copy.rs
+++ b/src/instructions/copy.rs
@@ -370,6 +370,34 @@ mod tests {
 
     Ok(())
   }
+  
+  #[test]
+  fn copy_heredoc_simple() -> Result<()> {
+    assert_eq!(
+      parse_single(
+        indoc!(r#"
+          COPY <<EOF /tmp/test.txt
+          hello world
+          EOF
+        "#),
+        Rule::copy
+      )?.into_copy().unwrap(),
+      CopyInstruction {
+        span: Span { start: 0, end: 41 },
+        flags: vec![],
+        sources: vec![SourceType::FileContents(SpannedString {
+          span: Span::new(25, 37),
+          content: "hello world\n".to_string(),
+        })],
+        destination: SpannedString {
+          span: Span::new(11, 24),
+          content: "/tmp/test.txt".to_string(),
+        },
+      }.into()
+    );
+
+    Ok(())
+  }
 
   #[test]
   fn copy_heredoc_incorrect() -> Result<()> {

--- a/src/instructions/copy.rs
+++ b/src/instructions/copy.rs
@@ -353,4 +353,74 @@ mod tests {
 
     Ok(())
   }
+
+  #[test]
+  fn copy_multi_heredoc() -> Result<()> {
+    assert_eq!(
+      parse_single(
+        indoc!(r#"
+          COPY <<EOF <<EOF2 /usr/share/nginx/html/index.html
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>Welcome to nginx!</title>
+          </head>
+          <body>
+              <h1>Welcome to nginx!</h1>
+          </body>
+          </html>
+          EOF
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>Welcome to nginx!</title>
+          </head>
+          <body>
+              <h1>Welcome to nginx!</h1>
+          </body>
+          </html>
+          EOF2
+        "#),
+        Rule::copy
+      )?.into_copy().unwrap(),
+      CopyInstruction {
+        span: Span { start: 0, end: 318 },
+        flags: vec![],
+        sources: vec![SourceType::FileContent(SpannedString {
+          span: Span::new(51, 180),
+          content: indoc!(r#"
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>Welcome to nginx!</title>
+          </head>
+          <body>
+              <h1>Welcome to nginx!</h1>
+          </body>
+          </html>
+          "#).to_string(),
+        }), 
+        SourceType::FileContent(SpannedString {
+          span: Span::new(184, 313),
+          content: indoc!(r#"
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>Welcome to nginx!</title>
+          </head>
+          <body>
+              <h1>Welcome to nginx!</h1>
+          </body>
+          </html>
+          "#).to_string(),
+        })],
+        destination: SpannedString {
+          span: Span::new(18, 50),
+          content: "/usr/share/nginx/html/index.html".to_string(),
+        },
+      }.into()
+    );
+
+    Ok(())
+  }
 }

--- a/src/instructions/env.rs
+++ b/src/instructions/env.rs
@@ -426,6 +426,34 @@ mod tests {
       ]
     );
 
+    assert_eq!(
+      parse_single(
+        indoc!(r#"
+          ENV \
+            # hello
+            foo \
+            # bar
+            Lorem ipsum dolor sit amet, \
+            # baz
+            consectetur adipiscing elit
+        "#),
+        Rule::env
+      )?.into_env().unwrap().vars,
+      vec![
+        EnvVar::new(
+          Span::new(18, 101),
+          SpannedString {
+            span: Span::new(18, 21),
+            content: "foo".to_string(),
+          },
+          BreakableString::new((34, 101))
+            .add_string((34, 62), "Lorem ipsum dolor sit amet, ")
+            .add_comment((66, 71), "# baz")
+            .add_string((72, 101), "  consectetur adipiscing elit")
+        )
+      ]
+    );
+
     Ok(())
   }
 }

--- a/src/instructions/run.rs
+++ b/src/instructions/run.rs
@@ -34,7 +34,11 @@ impl RunInstruction {
         span,
         expr: ShellOrExecExpr::Shell(parse_any_breakable(field)?),
       }),
-      _ => Err(unexpected_token(field)),
+      Rule::run_heredoc => Ok(RunInstruction {
+        span,
+        expr: ShellOrExecExpr::Heredoc(parse_heredoc(field)?)
+      }),
+      _ => Err(unexpected_token(field))
     }
   }
 
@@ -273,6 +277,27 @@ mod tests {
             content: "hello world".to_string(),
           }],
         })
+      }.into()
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn run_heredoc() -> Result<()> {
+    assert_eq!(
+      parse_single(indoc!(r#"RUN <<EOF
+        echo "hello world"
+        EOF
+      "#), Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 33),
+        expr: ShellOrExecExpr::Heredoc(Heredoc {
+          span: Span::new(4, 33),
+          // operator: "<<".to_string(),
+          // delimiter: "EOF".to_string(),
+          commands: vec!["echo \"hello world\"".to_string()],
+        }),
       }.into()
     );
 

--- a/src/instructions/run.rs
+++ b/src/instructions/run.rs
@@ -314,6 +314,26 @@ mod tests {
         .add_string((78, 85), "    baz")
     );
 
+    assert_eq!(
+      parse_single(
+        indoc!(r#"
+          run \
+              # hey
+              foo && \
+              # implicitly escaped
+              bar
+        "#),
+        Rule::run
+      )?
+        .into_run().unwrap()
+        .into_shell().unwrap(),
+      BreakableString::new((4, 61))
+        .add_comment((10, 15), "# hey")
+        .add_string((16, 27), "    foo && ")
+        .add_comment((33, 53), "# implicitly escaped")
+        .add_string((54, 61), "    bar")
+    );
+
     Ok(())
   }
 

--- a/src/instructions/run.rs
+++ b/src/instructions/run.rs
@@ -2,11 +2,11 @@
 
 use std::convert::TryFrom;
 
+use crate::Span;
 use crate::dockerfile_parser::Instruction;
 use crate::error::*;
-use crate::parser::*;
 use crate::util::*;
-use crate::Span;
+use crate::parser::*;
 
 /// A Dockerfile [`RUN` instruction][run].
 ///
@@ -16,294 +16,256 @@ use crate::Span;
 /// [run]: https://docs.docker.com/engine/reference/builder/#run
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RunInstruction {
-    pub span: Span,
-    pub expr: ShellOrExecExpr,
+  pub span: Span,
+  pub expr: ShellOrExecExpr,
 }
 
 impl RunInstruction {
-    pub(crate) fn from_record(record: Pair) -> Result<RunInstruction> {
-        let span = Span::from_pair(&record);
+  pub(crate) fn from_record(record: Pair) -> Result<RunInstruction> {
+    let span = Span::from_pair(&record);
 
-        // Skip any RUN flags and capture the expression pair (exec or shell)
-        let mut expr_pair: Option<Pair> = None;
-        for field in record.into_inner() {
-            match field.as_rule() {
-                Rule::run_flag => continue,
-                Rule::run_exec | Rule::run_shell => {
-                    expr_pair = Some(field);
-                    break;
-                }
-                Rule::comment => continue,
-                _ => return Err(unexpected_token(field)),
-            }
-        }
+    // Skip any RUN flags and capture the expression pair (exec or shell)
+    let mut expr_pair: Option<Pair> = None;
+    for field in record.into_inner() {
+      match field.as_rule() {
+        Rule::run_flag => continue,
+        Rule::run_exec | Rule::run_shell => {
+          expr_pair = Some(field);
+          break;
+        },
+        Rule::comment => continue,
+        _ => return Err(unexpected_token(field)),
+      }
+    }
 
-        let field = expr_pair.ok_or_else(|| Error::GenericParseError {
-            message: "missing run expression".into(),
+    let field = expr_pair.ok_or_else(|| Error::GenericParseError {
+      message: "missing run expression".into()
+    })?;
+
+    match field.as_rule() {
+      Rule::run_exec => Ok(RunInstruction {
+        span,
+        expr: ShellOrExecExpr::Exec(parse_string_array(field)?),
+      }),
+      Rule::run_shell => {
+        let mut field_iter = field.into_inner();
+        let first_field = field_iter.next().ok_or_else(|| Error::GenericParseError {
+          message: "missing run shell expression".into()
         })?;
-
-        match field.as_rule() {
-            Rule::run_exec => Ok(RunInstruction {
+        
+        match first_field.as_rule() {
+          Rule::run_heredoc => {
+            let heredoc = parse_heredoc(first_field)?;
+            Ok(RunInstruction {
+              span,
+              expr: ShellOrExecExpr::ShellWithHeredoc(BreakableString::new((4, 4)), heredoc),
+            })
+          },
+          Rule::any_breakable => {
+            let breakable = parse_any_breakable(first_field)?;
+            
+            if let Some(heredoc_field) = field_iter.next() {
+              let heredoc = parse_heredoc(heredoc_field)?;
+              Ok(RunInstruction {
                 span,
-                expr: ShellOrExecExpr::Exec(parse_string_array(field)?),
-            }),
-            Rule::run_shell => {
-                let mut field_iter = field.into_inner();
-                let first_field = field_iter.next().ok_or_else(|| Error::GenericParseError {
-                    message: "missing run shell expression".into(),
-                })?;
-
-                match first_field.as_rule() {
-                    Rule::run_heredoc => {
-                        let heredoc = parse_heredoc(first_field)?;
-                        Ok(RunInstruction {
-                            span,
-                            expr: ShellOrExecExpr::ShellWithHeredoc(
-                                BreakableString::new((4, 4)),
-                                heredoc,
-                            ),
-                        })
-                    }
-                    Rule::any_breakable => {
-                        let breakable = parse_any_breakable(first_field)?;
-
-                        if let Some(heredoc_field) = field_iter.next() {
-                            let heredoc = parse_heredoc(heredoc_field)?;
-                            Ok(RunInstruction {
-                                span,
-                                expr: ShellOrExecExpr::ShellWithHeredoc(breakable, heredoc),
-                            })
-                        } else {
-                            Ok(RunInstruction {
-                                span,
-                                expr: ShellOrExecExpr::Shell(breakable),
-                            })
-                        }
-                    }
-                    _ => Err(unexpected_token(first_field)),
-                }
+                expr: ShellOrExecExpr::ShellWithHeredoc(breakable, heredoc),
+              })
+            } else {
+              Ok(RunInstruction {
+                span,
+                expr: ShellOrExecExpr::Shell(breakable),
+              })
             }
-            _ => Err(unexpected_token(field)),
+          },
+          _ => Err(unexpected_token(first_field))
         }
+      },
+      _ => Err(unexpected_token(field))
     }
+  }
 
-    /// Unpacks this instruction into its inner value if it is a Shell-form
-    /// instruction, otherwise returns None.
-    pub fn into_shell(self) -> Option<BreakableString> {
-        self.expr.into_shell()
-    }
+  /// Unpacks this instruction into its inner value if it is a Shell-form
+  /// instruction, otherwise returns None.
+  pub fn into_shell(self) -> Option<BreakableString> {
+    self.expr.into_shell()
+  }
 
-    /// Unpacks this instruction into its inner value if it is a Shell-form
-    /// instruction, otherwise returns None.
-    pub fn as_shell(&self) -> Option<&BreakableString> {
-        self.expr.as_shell()
-    }
+  /// Unpacks this instruction into its inner value if it is a Shell-form
+  /// instruction, otherwise returns None.
+  pub fn as_shell(&self) -> Option<&BreakableString> {
+    self.expr.as_shell()
+  }
 
-    /// Unpacks this instruction into its inner value if it is an Exec-form
-    /// instruction, otherwise returns None.
-    pub fn into_exec(self) -> Option<StringArray> {
-        self.expr.into_exec()
-    }
+  /// Unpacks this instruction into its inner value if it is an Exec-form
+  /// instruction, otherwise returns None.
+  pub fn into_exec(self) -> Option<StringArray> {
+    self.expr.into_exec()
+  }
 
-    /// Unpacks this instruction into its inner value if it is an Exec-form
-    /// instruction, otherwise returns None.
-    pub fn as_exec(&self) -> Option<&StringArray> {
-        self.expr.as_exec()
-    }
+  /// Unpacks this instruction into its inner value if it is an Exec-form
+  /// instruction, otherwise returns None.
+  pub fn as_exec(&self) -> Option<&StringArray> {
+    self.expr.as_exec()
+  }
 }
 
 impl<'a> TryFrom<&'a Instruction> for &'a RunInstruction {
-    type Error = Error;
+  type Error = Error;
 
-    fn try_from(instruction: &'a Instruction) -> std::result::Result<Self, Self::Error> {
-        if let Instruction::Run(r) = instruction {
-            Ok(r)
-        } else {
-            Err(Error::ConversionError {
-                from: format!("{:?}", instruction),
-                to: "RunInstruction".into(),
-            })
-        }
+  fn try_from(instruction: &'a Instruction) -> std::result::Result<Self, Self::Error> {
+    if let Instruction::Run(r) = instruction {
+      Ok(r)
+    } else {
+      Err(Error::ConversionError {
+        from: format!("{:?}", instruction),
+        to: "RunInstruction".into()
+      })
     }
+  }
 }
 
 #[cfg(test)]
 mod tests {
-    use indoc::indoc;
-    use pretty_assertions::assert_eq;
+  use indoc::indoc;
+  use pretty_assertions::assert_eq;
 
-    use super::*;
-    use crate::test_util::*;
-    use crate::Span;
+  use super::*;
+  use crate::Span;
+  use crate::test_util::*;
 
-    #[test]
-    fn run_basic() -> Result<()> {
-        assert_eq!(
-            parse_single(r#"run echo "hello world""#, Rule::run)?
-                .as_run()
-                .unwrap()
-                .as_shell()
-                .unwrap(),
-            &BreakableString::new((4, 22)).add_string((4, 22), "echo \"hello world\"")
-        );
+  #[test]
+  fn run_basic() -> Result<()> {
+    assert_eq!(
+      parse_single(r#"run echo "hello world""#, Rule::run)?
+        .as_run().unwrap()
+        .as_shell().unwrap(),
+      &BreakableString::new((4, 22))
+        .add_string((4, 22), "echo \"hello world\"")
+    );
 
-        assert_eq!(
-            parse_single(r#"run ["echo", "hello world"]"#, Rule::run)?,
-            RunInstruction {
-                span: Span::new(0, 27),
-                expr: ShellOrExecExpr::Exec(StringArray {
-                    span: Span::new(4, 27),
-                    elements: vec![
-                        SpannedString {
-                            span: Span::new(5, 11),
-                            content: "echo".to_string(),
-                        },
-                        SpannedString {
-                            span: Span::new(13, 26),
-                            content: "hello world".to_string(),
-                        }
-                    ]
-                }),
-            }
-            .into()
-        );
+    assert_eq!(
+      parse_single(r#"run ["echo", "hello world"]"#, Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 27),
+        expr: ShellOrExecExpr::Exec(StringArray {
+          span: Span::new(4, 27),
+          elements: vec![SpannedString {
+            span: Span::new(5, 11),
+            content: "echo".to_string(),
+          }, SpannedString {
+            span: Span::new(13, 26),
+            content: "hello world".to_string(),
+          }]
+        }),
+      }.into()
+    );
 
-        Ok(())
-    }
+    Ok(())
+  }
 
-    #[test]
-    fn run_with_flags_shell() -> Result<()> {
-        assert_eq!(
-            parse_single(
-                r#"run --mount=type=cache,target=/root/.cache echo hello"#,
-                Rule::run
-            )?
-            .as_run()
-            .unwrap()
-            .as_shell()
-            .unwrap()
-            .to_string(),
-            "echo hello"
-        );
-        Ok(())
-    }
+  #[test]
+  fn run_with_flags_shell() -> Result<()> {
+    assert_eq!(
+      parse_single(r#"run --mount=type=cache,target=/root/.cache echo hello"#, Rule::run)?
+        .as_run().unwrap()
+        .as_shell().unwrap()
+        .to_string(),
+      "echo hello"
+    );
+    Ok(())
+  }
 
-    #[test]
-    fn run_with_flags_exec() -> Result<()> {
-        assert_eq!(
-            parse_single(r#"run --network=host ["echo","hi"]"#, Rule::run)?,
-            RunInstruction {
-                span: Span::new(0, 32),
-                expr: ShellOrExecExpr::Exec(StringArray {
-                    span: Span::new(19, 32),
-                    elements: vec![
-                        SpannedString {
-                            span: Span::new(20, 26),
-                            content: "echo".to_string(),
-                        },
-                        SpannedString {
-                            span: Span::new(27, 31),
-                            content: "hi".to_string(),
-                        }
-                    ],
-                }),
-            }
-            .into()
-        );
-        Ok(())
-    }
+  #[test]
+  fn run_with_flags_exec() -> Result<()> {
+    assert_eq!(
+      parse_single(r#"run --network=host ["echo","hi"]"#, Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 32),
+        expr: ShellOrExecExpr::Exec(StringArray {
+          span: Span::new(19, 32),
+          elements: vec![SpannedString {
+            span: Span::new(20, 26),
+            content: "echo".to_string(),
+          }, SpannedString {
+            span: Span::new(27, 31),
+            content: "hi".to_string(),
+          }],
+        }),
+      }.into()
+    );
+    Ok(())
+  }
 
-    #[test]
-    fn run_multiline_shell() -> Result<()> {
-        assert_eq!(
-            parse_single(
-                indoc!(
-                    r#"
+  #[test]
+  fn run_multiline_shell() -> Result<()> {
+    assert_eq!(
+      parse_single(indoc!(r#"
         run echo \
           "hello world"
-      "#
-                ),
-                Rule::run
-            )?
-            .as_run()
-            .unwrap()
-            .as_shell()
-            .unwrap(),
-            &BreakableString::new((4, 26))
-                .add_string((4, 9), "echo ")
-                .add_string((11, 26), "  \"hello world\"")
-        );
+      "#), Rule::run)?
+        .as_run().unwrap()
+        .as_shell().unwrap(),
+      &BreakableString::new((4, 26))
+        .add_string((4, 9), "echo ")
+        .add_string((11, 26), "  \"hello world\"")
+    );
 
-        assert_eq!(
-            parse_single(
-                indoc!(
-                    r#"
+    assert_eq!(
+      parse_single(indoc!(r#"
         run echo \
           "hello world"
-      "#
-                ),
-                Rule::run
-            )?
-            .as_run()
-            .unwrap()
-            .as_shell()
-            .unwrap()
-            .to_string(),
-            "echo   \"hello world\""
-        );
+      "#), Rule::run)?
+        .as_run().unwrap()
+        .as_shell().unwrap()
+        .to_string(),
+      "echo   \"hello world\""
+    );
 
-        // whitespace should be allowed, but my editor removes trailing whitespace
-        // :)
-        assert_eq!(
-            parse_single("run echo \\    \t  \t\t\n  \"hello world\"", Rule::run)?
-                .as_run()
-                .unwrap()
-                .as_shell()
-                .unwrap()
-                .to_string(),
-            "echo   \"hello world\""
-        );
+    // whitespace should be allowed, but my editor removes trailing whitespace
+    // :)
+    assert_eq!(
+      parse_single("run echo \\    \t  \t\t\n  \"hello world\"", Rule::run)?
+        .as_run().unwrap()
+        .as_shell().unwrap()
+        .to_string(),
+      "echo   \"hello world\""
+    );
 
-        Ok(())
-    }
+    Ok(())
+  }
 
-    #[test]
-    fn run_multiline_shell_comment() -> Result<()> {
-        assert_eq!(
-            parse_single(
-                indoc!(
-                    r#"
+  #[test]
+  fn run_multiline_shell_comment() -> Result<()> {
+    assert_eq!(
+      parse_single(
+        indoc!(r#"
           run foo && \
               # implicitly escaped
               bar && \
               # explicitly escaped \
               baz
-        "#
-                ),
-                Rule::run
-            )?
-            .into_run()
-            .unwrap()
-            .into_shell()
-            .unwrap(),
-            BreakableString::new((4, 85))
-                .add_string((4, 11), "foo && ")
-                .add_comment((17, 37), "# implicitly escaped")
-                .add_string((38, 49), "    bar && ")
-                .add_comment((55, 77), "# explicitly escaped \\")
-                .add_string((78, 85), "    baz")
-        );
+        "#),
+        Rule::run
+      )?
+        .into_run().unwrap()
+        .into_shell().unwrap(),
+      BreakableString::new((4, 85))
+        .add_string((4, 11), "foo && ")
+        .add_comment((17, 37), "# implicitly escaped")
+        .add_string((38, 49), "    bar && ")
+        .add_comment((55, 77), "# explicitly escaped \\")
+        .add_string((78, 85), "    baz")
+    );
 
-        Ok(())
-    }
+    Ok(())
+  }
 
-    #[test]
-    fn run_multiline_shell_large() -> Result<()> {
-        // note: the trailing `\` at the end is _almost_ nonsense and generates a
-        // warning from docker
-        let ins = parse_single(
-            indoc!(
-                r#"
+  #[test]
+  fn run_multiline_shell_large() -> Result<()> {
+    // note: the trailing `\` at the end is _almost_ nonsense and generates a
+    // warning from docker
+    let ins = parse_single(
+      indoc!(r#"
         run set -x && \
             # lorem ipsum
             echo "hello world" && \
@@ -315,165 +277,134 @@ mod tests {
             echo foo && \
             echo 'bar' \
             && echo baz \
-            # et dolore magna aliqua."#
-            ),
-            Rule::run,
-        )?
-        .into_run()
-        .unwrap()
-        .into_shell()
-        .unwrap();
+            # et dolore magna aliqua."#),
+      Rule::run
+    )?.into_run().unwrap().into_shell().unwrap();
 
-        assert_eq!(
-            ins,
-            BreakableString::new((4, 266))
-                .add_string((4, 14), "set -x && ")
-                .add_comment((20, 33), "# lorem ipsum")
-                .add_string((34, 60), "    echo \"hello world\" && ")
-                .add_comment((66, 83), "# dolor sit amet,")
-                .add_comment((88, 103), "# consectetur \\")
-                .add_comment((108, 128), "# adipiscing elit, \\")
-                .add_comment((133, 149), "# sed do eiusmod")
-                .add_comment((154, 183), "# tempor incididunt ut labore")
-                .add_string((184, 200), "    echo foo && ")
-                .add_string((202, 217), "    echo 'bar' ")
-                .add_string((219, 235), "    && echo baz ")
-                .add_comment((241, 266), "# et dolore magna aliqua.")
-        );
+    assert_eq!(
+      ins,
+      BreakableString::new((4, 266))
+        .add_string((4, 14), "set -x && ")
+        .add_comment((20, 33), "# lorem ipsum")
+        .add_string((34, 60), "    echo \"hello world\" && ")
+        .add_comment((66, 83), "# dolor sit amet,")
+        .add_comment((88, 103), "# consectetur \\")
+        .add_comment((108, 128), "# adipiscing elit, \\")
+        .add_comment((133, 149), "# sed do eiusmod")
+        .add_comment((154, 183), "# tempor incididunt ut labore")
+        .add_string((184, 200), "    echo foo && ")
+        .add_string((202, 217), "    echo 'bar' ")
+        .add_string((219, 235), "    && echo baz ")
+        .add_comment((241, 266), "# et dolore magna aliqua.")
+    );
 
-        assert_eq!(
-            ins.to_string(),
-            r#"set -x &&     echo "hello world" &&     echo foo &&     echo 'bar'     && echo baz "#
-        );
+    assert_eq!(
+      ins.to_string(),
+      r#"set -x &&     echo "hello world" &&     echo foo &&     echo 'bar'     && echo baz "#
+    );
 
-        Ok(())
-    }
+    Ok(())
+  }
 
-    #[test]
-    fn run_multline_exec() -> Result<()> {
-        assert_eq!(
-            parse_single(
-                r#"run\
+  #[test]
+  fn run_multline_exec() -> Result<()> {
+    assert_eq!(
+      parse_single(r#"run\
         [\
         "echo", \
         "hello world"\
-        ]"#,
-                Rule::run
-            )?,
-            RunInstruction {
-                span: Span::new(0, 66),
-                expr: ShellOrExecExpr::Exec(StringArray {
-                    span: Span::new(13, 66),
-                    elements: vec![
-                        SpannedString {
-                            span: Span::new(24, 30),
-                            content: "echo".to_string(),
-                        },
-                        SpannedString {
-                            span: Span::new(42, 55),
-                            content: "hello world".to_string(),
-                        }
-                    ],
-                }),
-            }
-            .into()
-        );
+        ]"#, Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 66),
+        expr: ShellOrExecExpr::Exec(StringArray {
+          span: Span::new(13, 66),
+          elements: vec![SpannedString {
+            span: Span::new(24, 30),
+            content: "echo".to_string(),
+          }, SpannedString {
+            span: Span::new(42, 55),
+            content: "hello world".to_string(),
+          }],
+        }),
+      }.into()
+    );
 
-        Ok(())
-    }
+    Ok(())
+  }
 
-    #[test]
-    fn run_multiline_exec_comment() -> Result<()> {
-        assert_eq!(
-            parse_single(
-                r#"run\
+  #[test]
+  fn run_multiline_exec_comment() -> Result<()> {
+    assert_eq!(
+      parse_single(r#"run\
         [\
         "echo", \
         "hello world"\
-        ]"#,
-                Rule::run
-            )?,
-            RunInstruction {
-                span: Span::new(0, 66),
-                expr: ShellOrExecExpr::Exec(StringArray {
-                    span: Span::new(13, 66),
-                    elements: vec![
-                        SpannedString {
-                            span: Span::new(24, 30),
-                            content: "echo".to_string(),
-                        },
-                        SpannedString {
-                            span: Span::new(42, 55),
-                            content: "hello world".to_string(),
-                        }
-                    ],
-                })
-            }
-            .into()
-        );
+        ]"#, Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 66),
+        expr: ShellOrExecExpr::Exec(StringArray {
+          span: Span::new(13, 66),
+          elements: vec![SpannedString {
+            span: Span::new(24, 30),
+            content: "echo".to_string(),
+          }, SpannedString {
+            span: Span::new(42, 55),
+            content: "hello world".to_string(),
+          }],
+        })
+      }.into()
+    );
 
-        Ok(())
-    }
+    Ok(())
+  }
 
-    #[test]
-    fn run_heredoc() -> Result<()> {
-        assert_eq!(
-            parse_single(
-                indoc!(
-                    r#"RUN <<EOF
+  #[test]
+  fn run_heredoc() -> Result<()> {
+    assert_eq!(
+      parse_single(indoc!(r#"RUN <<EOF
         echo "hello world"
         EOF
-      "#
-                ),
-                Rule::run
-            )?,
-            RunInstruction {
-                span: Span::new(0, 32),
-                expr: ShellOrExecExpr::ShellWithHeredoc(
-                    BreakableString::new((4, 4)),
-                    Heredoc {
-                        span: Span::new(4, 32),
-                        content: "<<EOF\necho \"hello world\"\nEOF".to_string(),
-                    }
-                ),
-            }
-            .into()
-        );
+      "#), Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 32),
+        expr: ShellOrExecExpr::ShellWithHeredoc(
+          BreakableString::new((4, 4)),
+          Heredoc {
+            span: Span::new(4, 32),
+            content: "<<EOF\necho \"hello world\"\nEOF".to_string(),
+          }
+        ),
+      }.into()
+    );
 
-        Ok(())
-    }
+    Ok(())
+  }
 
-    #[test]
-    fn run_heredoc_simple() -> Result<()> {
-        assert_eq!(
-            parse_single(
-                indoc!(
-                    r#"RUN <<EOF
+  #[test]
+  fn run_heredoc_simple() -> Result<()> {
+    assert_eq!(
+      parse_single(indoc!(r#"RUN <<EOF
         echo
         EOF
-      "#
-                ),
-                Rule::run
-            )?,
-            RunInstruction {
-                span: Span::new(0, 18),
-                expr: ShellOrExecExpr::ShellWithHeredoc(
-                    BreakableString::new((4, 4)),
-                    Heredoc {
-                        span: Span::new(4, 18),
-                        content: "<<EOF\necho\nEOF".to_string(),
-                    }
-                ),
-            }
-            .into()
-        );
+      "#), Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 18),
+        expr: ShellOrExecExpr::ShellWithHeredoc(
+          BreakableString::new((4, 4)),
+          Heredoc {
+            span: Span::new(4, 18),
+            content: "<<EOF\necho\nEOF".to_string(),
+          }
+        ),
+      }.into()
+    );
 
-        Ok(())
-    }
+    Ok(())
+  }
 
-    #[test]
-    fn run_shell_with_heredoc() -> Result<()> {
-        assert_eq!(
+  #[test]
+  fn run_shell_with_heredoc() -> Result<()> {
+    assert_eq!(
       parse_single(indoc!(r#"RUN python3 <<EOF
       with open("/hello", "w") as f:
           print("Hello", file=f)
@@ -493,85 +424,72 @@ mod tests {
       }.into()
     );
 
-        Ok(())
-    }
+    Ok(())
+  }
 
-    #[test]
-    fn run_shell_no_heredoc() -> Result<()> {
-        assert_eq!(
-            parse_single(r#"run echo "<<EOF EOF""#, Rule::run)?
-                .as_run()
-                .unwrap()
-                .as_shell()
-                .unwrap(),
-            &BreakableString::new((4, 20)).add_string((4, 20), "echo \"<<EOF EOF\"")
-        );
+  #[test]
+  fn run_shell_no_heredoc() -> Result<()> {
+    assert_eq!(
+      parse_single(r#"run echo "<<EOF EOF""#, Rule::run)?
+        .as_run().unwrap()
+        .as_shell().unwrap(),
+      &BreakableString::new((4, 20))
+        .add_string((4, 20), "echo \"<<EOF EOF\"")
+    );
 
-        Ok(())
-    }
+    Ok(())
+  }
 
-    #[test]
-    fn run_heredoc_empty() -> Result<()> {
-        // Empty heredoc should parse successfully
-        assert_eq!(
-            parse_single(
-                indoc!(
-                    r#"RUN <<EOF
+  #[test]
+  fn run_heredoc_empty() -> Result<()> {
+    // Empty heredoc should parse successfully
+    assert_eq!(
+      parse_single(indoc!(r#"RUN <<EOF
         EOF
-      "#
-                ),
-                Rule::run
-            )?,
-            RunInstruction {
-                span: Span::new(0, 13),
-                expr: ShellOrExecExpr::ShellWithHeredoc(
-                    BreakableString::new((4, 4)),
-                    Heredoc {
-                        span: Span::new(4, 13),
-                        content: "<<EOF\nEOF".to_string(),
-                    }
-                ),
-            }
-            .into()
-        );
+      "#), Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 13),
+        expr: ShellOrExecExpr::ShellWithHeredoc(
+          BreakableString::new((4, 4)),
+          Heredoc {
+            span: Span::new(4, 13),
+            content: "<<EOF\nEOF".to_string(),
+          }
+        ),
+      }.into()
+    );
 
-        Ok(())
-    }
+    Ok(())
+  }
 
-    #[test]
-    fn run_heredoc_with_comments() -> Result<()> {
-        // Comments inside heredoc should be treated as literal content
-        assert_eq!(
-            parse_single(
-                indoc!(
-                    r#"RUN <<EOF
+  #[test]
+  fn run_heredoc_with_comments() -> Result<()> {
+    // Comments inside heredoc should be treated as literal content
+    assert_eq!(
+      parse_single(indoc!(r#"RUN <<EOF
         # This is a comment
         echo "hello"
         EOF
-      "#
-                ),
-                Rule::run
-            )?,
-            RunInstruction {
-                span: Span::new(0, 46),
-                expr: ShellOrExecExpr::ShellWithHeredoc(
-                    BreakableString::new((4, 4)),
-                    Heredoc {
-                        span: Span::new(4, 46),
-                        content: "<<EOF\n# This is a comment\necho \"hello\"\nEOF".to_string(),
-                    }
-                ),
-            }
-            .into()
-        );
+      "#), Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 46),
+        expr: ShellOrExecExpr::ShellWithHeredoc(
+          BreakableString::new((4, 4)),
+          Heredoc {
+            span: Span::new(4, 46),
+            content: "<<EOF\n# This is a comment\necho \"hello\"\nEOF".to_string(),
+          }
+        ),
+      }.into()
+    );
 
-        Ok(())
-    }
+    Ok(())
+  }
 
-    #[test]
-    fn run_heredoc_special_characters() -> Result<()> {
-        // Special characters should be preserved literally
-        assert_eq!(
+  #[test]
+  fn run_heredoc_special_characters() -> Result<()> {
+    // Special characters should be preserved literally
+    assert_eq!(
       parse_single(indoc!(r#"RUN <<EOF
         echo "quotes" && echo 'apostrophes'
         echo $VAR ${BRACE} \backslash
@@ -589,63 +507,52 @@ mod tests {
       }.into()
     );
 
-        Ok(())
-    }
+    Ok(())
+  }
 
-    #[test]
-    fn run_heredoc_whitespace_delimiter() -> Result<()> {
-        // Whitespace around delimiter should be handled
-        assert_eq!(
-            parse_single(
-                indoc!(
-                    r#"RUN <<   DELIM   
+  #[test]
+  fn run_heredoc_whitespace_delimiter() -> Result<()> {
+    // Whitespace around delimiter should be handled
+    assert_eq!(
+      parse_single(indoc!(r#"RUN <<   DELIM   
         content
         DELIM
-      "#
-                ),
-                Rule::run
-            )?,
-            RunInstruction {
-                span: Span::new(0, 31),
-                expr: ShellOrExecExpr::ShellWithHeredoc(
-                    BreakableString::new((4, 4)),
-                    Heredoc {
-                        span: Span::new(4, 31),
-                        content: "<<   DELIM   \ncontent\nDELIM".to_string(),
-                    }
-                ),
-            }
-            .into()
-        );
+      "#), Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 31),
+        expr: ShellOrExecExpr::ShellWithHeredoc(
+          BreakableString::new((4, 4)),
+          Heredoc {
+            span: Span::new(4, 31),
+            content: "<<   DELIM   \ncontent\nDELIM".to_string(),
+          }
+        ),
+      }.into()
+    );
 
-        Ok(())
-    }
+    Ok(())
+  }
 
-    #[test]
-    fn run_heredoc_with_destination() -> Result<()> {
-        assert_eq!(
-            parse_single(
-                indoc!(
-                    r#"RUN tee <<EOF /file
+  #[test]
+  fn run_heredoc_with_destination() -> Result<()> {
+    assert_eq!(
+      parse_single(indoc!(r#"RUN tee <<EOF /file
       hello world
       EOF
-      "#
-                ),
-                Rule::run
-            )?,
-            RunInstruction {
-                span: Span::new(0, 35),
-                expr: ShellOrExecExpr::ShellWithHeredoc(
-                    BreakableString::new((4, 8)).add_string((4, 8), "tee "),
-                    Heredoc {
-                        span: Span::new(8, 35),
-                        content: "<<EOF /file\nhello world\nEOF".to_string(),
-                    }
-                ),
-            }
-            .into()
-        );
+      "#), Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 35),
+        expr: ShellOrExecExpr::ShellWithHeredoc(
+          BreakableString::new((4, 8))
+            .add_string((4, 8), "tee "),
+          Heredoc {
+            span: Span::new(8, 35),
+            content: "<<EOF /file\nhello world\nEOF".to_string(),
+          }
+        ),
+      }.into()
+    );
 
-        Ok(())
-    }
+    Ok(())
+  }
 }

--- a/src/instructions/run.rs
+++ b/src/instructions/run.rs
@@ -2,11 +2,11 @@
 
 use std::convert::TryFrom;
 
-use crate::Span;
 use crate::dockerfile_parser::Instruction;
 use crate::error::*;
-use crate::util::*;
 use crate::parser::*;
+use crate::util::*;
+use crate::Span;
 
 /// A Dockerfile [`RUN` instruction][run].
 ///
@@ -16,204 +16,294 @@ use crate::parser::*;
 /// [run]: https://docs.docker.com/engine/reference/builder/#run
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RunInstruction {
-  pub span: Span,
-  pub expr: ShellOrExecExpr,
+    pub span: Span,
+    pub expr: ShellOrExecExpr,
 }
 
 impl RunInstruction {
-  pub(crate) fn from_record(record: Pair) -> Result<RunInstruction> {
-    let span = Span::from_pair(&record);
-    let field = record.into_inner().next().unwrap();
+    pub(crate) fn from_record(record: Pair) -> Result<RunInstruction> {
+        let span = Span::from_pair(&record);
 
-    match field.as_rule() {
-      Rule::run_exec => Ok(RunInstruction {
-        span,
-        expr: ShellOrExecExpr::Exec(parse_string_array(field)?),
-      }),
-      Rule::run_shell => {
-        let mut field_iter = field.into_inner();
-        let first_field = field_iter.next().unwrap();
-        
-        match first_field.as_rule() {
-          Rule::run_heredoc => {
-            let heredoc = parse_heredoc(first_field)?;
-            Ok(RunInstruction {
-              span,
-              expr: ShellOrExecExpr::ShellWithHeredoc(BreakableString::new((4, 4)), heredoc),
-            })
-          },
-          Rule::any_breakable => {
-            let breakable = parse_any_breakable(first_field)?;
-            
-            if let Some(heredoc_field) = field_iter.next() {
-              let heredoc = parse_heredoc(heredoc_field)?;
-              Ok(RunInstruction {
-                span,
-                expr: ShellOrExecExpr::ShellWithHeredoc(breakable, heredoc),
-              })
-            } else {
-              Ok(RunInstruction {
-                span,
-                expr: ShellOrExecExpr::Shell(breakable),
-              })
+        // Skip any RUN flags and capture the expression pair (exec or shell)
+        let mut expr_pair: Option<Pair> = None;
+        for field in record.into_inner() {
+            match field.as_rule() {
+                Rule::run_flag => continue,
+                Rule::run_exec | Rule::run_shell => {
+                    expr_pair = Some(field);
+                    break;
+                }
+                Rule::comment => continue,
+                _ => return Err(unexpected_token(field)),
             }
-          },
-          _ => Err(unexpected_token(first_field))
         }
-      },
-      _ => Err(unexpected_token(field))
+
+        let field = expr_pair.ok_or_else(|| Error::GenericParseError {
+            message: "missing run expression".into(),
+        })?;
+
+        match field.as_rule() {
+            Rule::run_exec => Ok(RunInstruction {
+                span,
+                expr: ShellOrExecExpr::Exec(parse_string_array(field)?),
+            }),
+            Rule::run_shell => {
+                let mut field_iter = field.into_inner();
+                let first_field = field_iter.next().ok_or_else(|| Error::GenericParseError {
+                    message: "missing run shell expression".into(),
+                })?;
+
+                match first_field.as_rule() {
+                    Rule::run_heredoc => {
+                        let heredoc = parse_heredoc(first_field)?;
+                        Ok(RunInstruction {
+                            span,
+                            expr: ShellOrExecExpr::ShellWithHeredoc(
+                                BreakableString::new((4, 4)),
+                                heredoc,
+                            ),
+                        })
+                    }
+                    Rule::any_breakable => {
+                        let breakable = parse_any_breakable(first_field)?;
+
+                        if let Some(heredoc_field) = field_iter.next() {
+                            let heredoc = parse_heredoc(heredoc_field)?;
+                            Ok(RunInstruction {
+                                span,
+                                expr: ShellOrExecExpr::ShellWithHeredoc(breakable, heredoc),
+                            })
+                        } else {
+                            Ok(RunInstruction {
+                                span,
+                                expr: ShellOrExecExpr::Shell(breakable),
+                            })
+                        }
+                    }
+                    _ => Err(unexpected_token(first_field)),
+                }
+            }
+            _ => Err(unexpected_token(field)),
+        }
     }
-  }
 
-  /// Unpacks this instruction into its inner value if it is a Shell-form
-  /// instruction, otherwise returns None.
-  pub fn into_shell(self) -> Option<BreakableString> {
-    self.expr.into_shell()
-  }
+    /// Unpacks this instruction into its inner value if it is a Shell-form
+    /// instruction, otherwise returns None.
+    pub fn into_shell(self) -> Option<BreakableString> {
+        self.expr.into_shell()
+    }
 
-  /// Unpacks this instruction into its inner value if it is a Shell-form
-  /// instruction, otherwise returns None.
-  pub fn as_shell(&self) -> Option<&BreakableString> {
-    self.expr.as_shell()
-  }
+    /// Unpacks this instruction into its inner value if it is a Shell-form
+    /// instruction, otherwise returns None.
+    pub fn as_shell(&self) -> Option<&BreakableString> {
+        self.expr.as_shell()
+    }
 
-  /// Unpacks this instruction into its inner value if it is an Exec-form
-  /// instruction, otherwise returns None.
-  pub fn into_exec(self) -> Option<StringArray> {
-    self.expr.into_exec()
-  }
+    /// Unpacks this instruction into its inner value if it is an Exec-form
+    /// instruction, otherwise returns None.
+    pub fn into_exec(self) -> Option<StringArray> {
+        self.expr.into_exec()
+    }
 
-  /// Unpacks this instruction into its inner value if it is an Exec-form
-  /// instruction, otherwise returns None.
-  pub fn as_exec(&self) -> Option<&StringArray> {
-    self.expr.as_exec()
-  }
+    /// Unpacks this instruction into its inner value if it is an Exec-form
+    /// instruction, otherwise returns None.
+    pub fn as_exec(&self) -> Option<&StringArray> {
+        self.expr.as_exec()
+    }
 }
 
 impl<'a> TryFrom<&'a Instruction> for &'a RunInstruction {
-  type Error = Error;
+    type Error = Error;
 
-  fn try_from(instruction: &'a Instruction) -> std::result::Result<Self, Self::Error> {
-    if let Instruction::Run(r) = instruction {
-      Ok(r)
-    } else {
-      Err(Error::ConversionError {
-        from: format!("{:?}", instruction),
-        to: "RunInstruction".into()
-      })
+    fn try_from(instruction: &'a Instruction) -> std::result::Result<Self, Self::Error> {
+        if let Instruction::Run(r) = instruction {
+            Ok(r)
+        } else {
+            Err(Error::ConversionError {
+                from: format!("{:?}", instruction),
+                to: "RunInstruction".into(),
+            })
+        }
     }
-  }
 }
 
 #[cfg(test)]
 mod tests {
-  use indoc::indoc;
-  use pretty_assertions::assert_eq;
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
 
-  use super::*;
-  use crate::Span;
-  use crate::test_util::*;
+    use super::*;
+    use crate::test_util::*;
+    use crate::Span;
 
-  #[test]
-  fn run_basic() -> Result<()> {
-    assert_eq!(
-      parse_single(r#"run echo "hello world""#, Rule::run)?
-        .as_run().unwrap()
-        .as_shell().unwrap(),
-      &BreakableString::new((4, 22))
-        .add_string((4, 22), "echo \"hello world\"")
-    );
+    #[test]
+    fn run_basic() -> Result<()> {
+        assert_eq!(
+            parse_single(r#"run echo "hello world""#, Rule::run)?
+                .as_run()
+                .unwrap()
+                .as_shell()
+                .unwrap(),
+            &BreakableString::new((4, 22)).add_string((4, 22), "echo \"hello world\"")
+        );
 
-    assert_eq!(
-      parse_single(r#"run ["echo", "hello world"]"#, Rule::run)?,
-      RunInstruction {
-        span: Span::new(0, 27),
-        expr: ShellOrExecExpr::Exec(StringArray {
-          span: Span::new(4, 27),
-          elements: vec![SpannedString {
-            span: Span::new(5, 11),
-            content: "echo".to_string(),
-          }, SpannedString {
-            span: Span::new(13, 26),
-            content: "hello world".to_string(),
-          }]
-        }),
-      }.into()
-    );
+        assert_eq!(
+            parse_single(r#"run ["echo", "hello world"]"#, Rule::run)?,
+            RunInstruction {
+                span: Span::new(0, 27),
+                expr: ShellOrExecExpr::Exec(StringArray {
+                    span: Span::new(4, 27),
+                    elements: vec![
+                        SpannedString {
+                            span: Span::new(5, 11),
+                            content: "echo".to_string(),
+                        },
+                        SpannedString {
+                            span: Span::new(13, 26),
+                            content: "hello world".to_string(),
+                        }
+                    ]
+                }),
+            }
+            .into()
+        );
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[test]
-  fn run_multiline_shell() -> Result<()> {
-    assert_eq!(
-      parse_single(indoc!(r#"
+    #[test]
+    fn run_with_flags_shell() -> Result<()> {
+        assert_eq!(
+            parse_single(
+                r#"run --mount=type=cache,target=/root/.cache echo hello"#,
+                Rule::run
+            )?
+            .as_run()
+            .unwrap()
+            .as_shell()
+            .unwrap()
+            .to_string(),
+            "echo hello"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn run_with_flags_exec() -> Result<()> {
+        assert_eq!(
+            parse_single(r#"run --network=host ["echo","hi"]"#, Rule::run)?,
+            RunInstruction {
+                span: Span::new(0, 32),
+                expr: ShellOrExecExpr::Exec(StringArray {
+                    span: Span::new(19, 32),
+                    elements: vec![
+                        SpannedString {
+                            span: Span::new(20, 26),
+                            content: "echo".to_string(),
+                        },
+                        SpannedString {
+                            span: Span::new(27, 31),
+                            content: "hi".to_string(),
+                        }
+                    ],
+                }),
+            }
+            .into()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn run_multiline_shell() -> Result<()> {
+        assert_eq!(
+            parse_single(
+                indoc!(
+                    r#"
         run echo \
           "hello world"
-      "#), Rule::run)?
-        .as_run().unwrap()
-        .as_shell().unwrap(),
-      &BreakableString::new((4, 26))
-        .add_string((4, 9), "echo ")
-        .add_string((11, 26), "  \"hello world\"")
-    );
+      "#
+                ),
+                Rule::run
+            )?
+            .as_run()
+            .unwrap()
+            .as_shell()
+            .unwrap(),
+            &BreakableString::new((4, 26))
+                .add_string((4, 9), "echo ")
+                .add_string((11, 26), "  \"hello world\"")
+        );
 
-    assert_eq!(
-      parse_single(indoc!(r#"
+        assert_eq!(
+            parse_single(
+                indoc!(
+                    r#"
         run echo \
           "hello world"
-      "#), Rule::run)?
-        .as_run().unwrap()
-        .as_shell().unwrap()
-        .to_string(),
-      "echo   \"hello world\""
-    );
+      "#
+                ),
+                Rule::run
+            )?
+            .as_run()
+            .unwrap()
+            .as_shell()
+            .unwrap()
+            .to_string(),
+            "echo   \"hello world\""
+        );
 
-    // whitespace should be allowed, but my editor removes trailing whitespace
-    // :)
-    assert_eq!(
-      parse_single("run echo \\    \t  \t\t\n  \"hello world\"", Rule::run)?
-        .as_run().unwrap()
-        .as_shell().unwrap()
-        .to_string(),
-      "echo   \"hello world\""
-    );
+        // whitespace should be allowed, but my editor removes trailing whitespace
+        // :)
+        assert_eq!(
+            parse_single("run echo \\    \t  \t\t\n  \"hello world\"", Rule::run)?
+                .as_run()
+                .unwrap()
+                .as_shell()
+                .unwrap()
+                .to_string(),
+            "echo   \"hello world\""
+        );
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[test]
-  fn run_multiline_shell_comment() -> Result<()> {
-    assert_eq!(
-      parse_single(
-        indoc!(r#"
+    #[test]
+    fn run_multiline_shell_comment() -> Result<()> {
+        assert_eq!(
+            parse_single(
+                indoc!(
+                    r#"
           run foo && \
               # implicitly escaped
               bar && \
               # explicitly escaped \
               baz
-        "#),
-        Rule::run
-      )?
-        .into_run().unwrap()
-        .into_shell().unwrap(),
-      BreakableString::new((4, 85))
-        .add_string((4, 11), "foo && ")
-        .add_comment((17, 37), "# implicitly escaped")
-        .add_string((38, 49), "    bar && ")
-        .add_comment((55, 77), "# explicitly escaped \\")
-        .add_string((78, 85), "    baz")
-    );
+        "#
+                ),
+                Rule::run
+            )?
+            .into_run()
+            .unwrap()
+            .into_shell()
+            .unwrap(),
+            BreakableString::new((4, 85))
+                .add_string((4, 11), "foo && ")
+                .add_comment((17, 37), "# implicitly escaped")
+                .add_string((38, 49), "    bar && ")
+                .add_comment((55, 77), "# explicitly escaped \\")
+                .add_string((78, 85), "    baz")
+        );
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[test]
-  fn run_multiline_shell_large() -> Result<()> {
-    // note: the trailing `\` at the end is _almost_ nonsense and generates a
-    // warning from docker
-    let ins = parse_single(
-      indoc!(r#"
+    #[test]
+    fn run_multiline_shell_large() -> Result<()> {
+        // note: the trailing `\` at the end is _almost_ nonsense and generates a
+        // warning from docker
+        let ins = parse_single(
+            indoc!(
+                r#"
         run set -x && \
             # lorem ipsum
             echo "hello world" && \
@@ -225,134 +315,165 @@ mod tests {
             echo foo && \
             echo 'bar' \
             && echo baz \
-            # et dolore magna aliqua."#),
-      Rule::run
-    )?.into_run().unwrap().into_shell().unwrap();
+            # et dolore magna aliqua."#
+            ),
+            Rule::run,
+        )?
+        .into_run()
+        .unwrap()
+        .into_shell()
+        .unwrap();
 
-    assert_eq!(
-      ins,
-      BreakableString::new((4, 266))
-        .add_string((4, 14), "set -x && ")
-        .add_comment((20, 33), "# lorem ipsum")
-        .add_string((34, 60), "    echo \"hello world\" && ")
-        .add_comment((66, 83), "# dolor sit amet,")
-        .add_comment((88, 103), "# consectetur \\")
-        .add_comment((108, 128), "# adipiscing elit, \\")
-        .add_comment((133, 149), "# sed do eiusmod")
-        .add_comment((154, 183), "# tempor incididunt ut labore")
-        .add_string((184, 200), "    echo foo && ")
-        .add_string((202, 217), "    echo 'bar' ")
-        .add_string((219, 235), "    && echo baz ")
-        .add_comment((241, 266), "# et dolore magna aliqua.")
-    );
+        assert_eq!(
+            ins,
+            BreakableString::new((4, 266))
+                .add_string((4, 14), "set -x && ")
+                .add_comment((20, 33), "# lorem ipsum")
+                .add_string((34, 60), "    echo \"hello world\" && ")
+                .add_comment((66, 83), "# dolor sit amet,")
+                .add_comment((88, 103), "# consectetur \\")
+                .add_comment((108, 128), "# adipiscing elit, \\")
+                .add_comment((133, 149), "# sed do eiusmod")
+                .add_comment((154, 183), "# tempor incididunt ut labore")
+                .add_string((184, 200), "    echo foo && ")
+                .add_string((202, 217), "    echo 'bar' ")
+                .add_string((219, 235), "    && echo baz ")
+                .add_comment((241, 266), "# et dolore magna aliqua.")
+        );
 
-    assert_eq!(
-      ins.to_string(),
-      r#"set -x &&     echo "hello world" &&     echo foo &&     echo 'bar'     && echo baz "#
-    );
+        assert_eq!(
+            ins.to_string(),
+            r#"set -x &&     echo "hello world" &&     echo foo &&     echo 'bar'     && echo baz "#
+        );
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[test]
-  fn run_multline_exec() -> Result<()> {
-    assert_eq!(
-      parse_single(r#"run\
+    #[test]
+    fn run_multline_exec() -> Result<()> {
+        assert_eq!(
+            parse_single(
+                r#"run\
         [\
         "echo", \
         "hello world"\
-        ]"#, Rule::run)?,
-      RunInstruction {
-        span: Span::new(0, 66),
-        expr: ShellOrExecExpr::Exec(StringArray {
-          span: Span::new(13, 66),
-          elements: vec![SpannedString {
-            span: Span::new(24, 30),
-            content: "echo".to_string(),
-          }, SpannedString {
-            span: Span::new(42, 55),
-            content: "hello world".to_string(),
-          }],
-        }),
-      }.into()
-    );
+        ]"#,
+                Rule::run
+            )?,
+            RunInstruction {
+                span: Span::new(0, 66),
+                expr: ShellOrExecExpr::Exec(StringArray {
+                    span: Span::new(13, 66),
+                    elements: vec![
+                        SpannedString {
+                            span: Span::new(24, 30),
+                            content: "echo".to_string(),
+                        },
+                        SpannedString {
+                            span: Span::new(42, 55),
+                            content: "hello world".to_string(),
+                        }
+                    ],
+                }),
+            }
+            .into()
+        );
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[test]
-  fn run_multiline_exec_comment() -> Result<()> {
-    assert_eq!(
-      parse_single(r#"run\
+    #[test]
+    fn run_multiline_exec_comment() -> Result<()> {
+        assert_eq!(
+            parse_single(
+                r#"run\
         [\
         "echo", \
         "hello world"\
-        ]"#, Rule::run)?,
-      RunInstruction {
-        span: Span::new(0, 66),
-        expr: ShellOrExecExpr::Exec(StringArray {
-          span: Span::new(13, 66),
-          elements: vec![SpannedString {
-            span: Span::new(24, 30),
-            content: "echo".to_string(),
-          }, SpannedString {
-            span: Span::new(42, 55),
-            content: "hello world".to_string(),
-          }],
-        })
-      }.into()
-    );
+        ]"#,
+                Rule::run
+            )?,
+            RunInstruction {
+                span: Span::new(0, 66),
+                expr: ShellOrExecExpr::Exec(StringArray {
+                    span: Span::new(13, 66),
+                    elements: vec![
+                        SpannedString {
+                            span: Span::new(24, 30),
+                            content: "echo".to_string(),
+                        },
+                        SpannedString {
+                            span: Span::new(42, 55),
+                            content: "hello world".to_string(),
+                        }
+                    ],
+                })
+            }
+            .into()
+        );
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[test]
-  fn run_heredoc() -> Result<()> {
-    assert_eq!(
-      parse_single(indoc!(r#"RUN <<EOF
+    #[test]
+    fn run_heredoc() -> Result<()> {
+        assert_eq!(
+            parse_single(
+                indoc!(
+                    r#"RUN <<EOF
         echo "hello world"
         EOF
-      "#), Rule::run)?,
-      RunInstruction {
-        span: Span::new(0, 32),
-        expr: ShellOrExecExpr::ShellWithHeredoc(
-          BreakableString::new((4, 4)),
-          Heredoc {
-            span: Span::new(4, 32),
-            content: "<<EOF\necho \"hello world\"\nEOF".to_string(),
-          }
-        ),
-      }.into()
-    );
+      "#
+                ),
+                Rule::run
+            )?,
+            RunInstruction {
+                span: Span::new(0, 32),
+                expr: ShellOrExecExpr::ShellWithHeredoc(
+                    BreakableString::new((4, 4)),
+                    Heredoc {
+                        span: Span::new(4, 32),
+                        content: "<<EOF\necho \"hello world\"\nEOF".to_string(),
+                    }
+                ),
+            }
+            .into()
+        );
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[test]
-  fn run_heredoc_simple() -> Result<()> {
-    assert_eq!(
-      parse_single(indoc!(r#"RUN <<EOF
+    #[test]
+    fn run_heredoc_simple() -> Result<()> {
+        assert_eq!(
+            parse_single(
+                indoc!(
+                    r#"RUN <<EOF
         echo
         EOF
-      "#), Rule::run)?,
-      RunInstruction {
-        span: Span::new(0, 18),
-        expr: ShellOrExecExpr::ShellWithHeredoc(
-          BreakableString::new((4, 4)),
-          Heredoc {
-            span: Span::new(4, 18),
-            content: "<<EOF\necho\nEOF".to_string(),
-          }
-        ),
-      }.into()
-    );
+      "#
+                ),
+                Rule::run
+            )?,
+            RunInstruction {
+                span: Span::new(0, 18),
+                expr: ShellOrExecExpr::ShellWithHeredoc(
+                    BreakableString::new((4, 4)),
+                    Heredoc {
+                        span: Span::new(4, 18),
+                        content: "<<EOF\necho\nEOF".to_string(),
+                    }
+                ),
+            }
+            .into()
+        );
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[test]
-  fn run_shell_with_heredoc() -> Result<()> {
-    assert_eq!(
+    #[test]
+    fn run_shell_with_heredoc() -> Result<()> {
+        assert_eq!(
       parse_single(indoc!(r#"RUN python3 <<EOF
       with open("/hello", "w") as f:
           print("Hello", file=f)
@@ -372,72 +493,85 @@ mod tests {
       }.into()
     );
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[test]
-  fn run_shell_no_heredoc() -> Result<()> {
-    assert_eq!(
-      parse_single(r#"run echo "<<EOF EOF""#, Rule::run)?
-        .as_run().unwrap()
-        .as_shell().unwrap(),
-      &BreakableString::new((4, 20))
-        .add_string((4, 20), "echo \"<<EOF EOF\"")
-    );
+    #[test]
+    fn run_shell_no_heredoc() -> Result<()> {
+        assert_eq!(
+            parse_single(r#"run echo "<<EOF EOF""#, Rule::run)?
+                .as_run()
+                .unwrap()
+                .as_shell()
+                .unwrap(),
+            &BreakableString::new((4, 20)).add_string((4, 20), "echo \"<<EOF EOF\"")
+        );
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[test]
-  fn run_heredoc_empty() -> Result<()> {
-    // Empty heredoc should parse successfully
-    assert_eq!(
-      parse_single(indoc!(r#"RUN <<EOF
+    #[test]
+    fn run_heredoc_empty() -> Result<()> {
+        // Empty heredoc should parse successfully
+        assert_eq!(
+            parse_single(
+                indoc!(
+                    r#"RUN <<EOF
         EOF
-      "#), Rule::run)?,
-      RunInstruction {
-        span: Span::new(0, 13),
-        expr: ShellOrExecExpr::ShellWithHeredoc(
-          BreakableString::new((4, 4)),
-          Heredoc {
-            span: Span::new(4, 13),
-            content: "<<EOF\nEOF".to_string(),
-          }
-        ),
-      }.into()
-    );
+      "#
+                ),
+                Rule::run
+            )?,
+            RunInstruction {
+                span: Span::new(0, 13),
+                expr: ShellOrExecExpr::ShellWithHeredoc(
+                    BreakableString::new((4, 4)),
+                    Heredoc {
+                        span: Span::new(4, 13),
+                        content: "<<EOF\nEOF".to_string(),
+                    }
+                ),
+            }
+            .into()
+        );
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[test]
-  fn run_heredoc_with_comments() -> Result<()> {
-    // Comments inside heredoc should be treated as literal content
-    assert_eq!(
-      parse_single(indoc!(r#"RUN <<EOF
+    #[test]
+    fn run_heredoc_with_comments() -> Result<()> {
+        // Comments inside heredoc should be treated as literal content
+        assert_eq!(
+            parse_single(
+                indoc!(
+                    r#"RUN <<EOF
         # This is a comment
         echo "hello"
         EOF
-      "#), Rule::run)?,
-      RunInstruction {
-        span: Span::new(0, 46),
-        expr: ShellOrExecExpr::ShellWithHeredoc(
-          BreakableString::new((4, 4)),
-          Heredoc {
-            span: Span::new(4, 46),
-            content: "<<EOF\n# This is a comment\necho \"hello\"\nEOF".to_string(),
-          }
-        ),
-      }.into()
-    );
+      "#
+                ),
+                Rule::run
+            )?,
+            RunInstruction {
+                span: Span::new(0, 46),
+                expr: ShellOrExecExpr::ShellWithHeredoc(
+                    BreakableString::new((4, 4)),
+                    Heredoc {
+                        span: Span::new(4, 46),
+                        content: "<<EOF\n# This is a comment\necho \"hello\"\nEOF".to_string(),
+                    }
+                ),
+            }
+            .into()
+        );
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[test]
-  fn run_heredoc_special_characters() -> Result<()> {
-    // Special characters should be preserved literally
-    assert_eq!(
+    #[test]
+    fn run_heredoc_special_characters() -> Result<()> {
+        // Special characters should be preserved literally
+        assert_eq!(
       parse_single(indoc!(r#"RUN <<EOF
         echo "quotes" && echo 'apostrophes'
         echo $VAR ${BRACE} \backslash
@@ -455,52 +589,63 @@ mod tests {
       }.into()
     );
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[test]
-  fn run_heredoc_whitespace_delimiter() -> Result<()> {
-    // Whitespace around delimiter should be handled
-    assert_eq!(
-      parse_single(indoc!(r#"RUN <<   DELIM   
+    #[test]
+    fn run_heredoc_whitespace_delimiter() -> Result<()> {
+        // Whitespace around delimiter should be handled
+        assert_eq!(
+            parse_single(
+                indoc!(
+                    r#"RUN <<   DELIM   
         content
         DELIM
-      "#), Rule::run)?,
-      RunInstruction {
-        span: Span::new(0, 31),
-        expr: ShellOrExecExpr::ShellWithHeredoc(
-          BreakableString::new((4, 4)),
-          Heredoc {
-            span: Span::new(4, 31),
-            content: "<<   DELIM   \ncontent\nDELIM".to_string(),
-          }
-        ),
-      }.into()
-    );
+      "#
+                ),
+                Rule::run
+            )?,
+            RunInstruction {
+                span: Span::new(0, 31),
+                expr: ShellOrExecExpr::ShellWithHeredoc(
+                    BreakableString::new((4, 4)),
+                    Heredoc {
+                        span: Span::new(4, 31),
+                        content: "<<   DELIM   \ncontent\nDELIM".to_string(),
+                    }
+                ),
+            }
+            .into()
+        );
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  #[test]
-  fn run_heredoc_with_destination() -> Result<()> {
-    assert_eq!(
-      parse_single(indoc!(r#"RUN tee <<EOF /file
+    #[test]
+    fn run_heredoc_with_destination() -> Result<()> {
+        assert_eq!(
+            parse_single(
+                indoc!(
+                    r#"RUN tee <<EOF /file
       hello world
       EOF
-      "#), Rule::run)?,
-      RunInstruction {
-        span: Span::new(0, 35),
-        expr: ShellOrExecExpr::ShellWithHeredoc(
-          BreakableString::new((4, 8))
-            .add_string((4, 8), "tee "),
-          Heredoc {
-            span: Span::new(8, 35),
-            content: "<<EOF /file\nhello world\nEOF".to_string(),
-          }
-        ),
-      }.into()
-    );
+      "#
+                ),
+                Rule::run
+            )?,
+            RunInstruction {
+                span: Span::new(0, 35),
+                expr: ShellOrExecExpr::ShellWithHeredoc(
+                    BreakableString::new((4, 8)).add_string((4, 8), "tee "),
+                    Heredoc {
+                        span: Span::new(8, 35),
+                        content: "<<EOF /file\nhello world\nEOF".to_string(),
+                    }
+                ),
+            }
+            .into()
+        );
 
-    Ok(())
-  }
+        Ok(())
+    }
 }

--- a/src/instructions/run.rs
+++ b/src/instructions/run.rs
@@ -352,4 +352,17 @@ mod tests {
 
     Ok(())
   }
+
+  #[test]
+  fn run_shell_no_heredoc() -> Result<()> {
+    assert_eq!(
+      parse_single(r#"run echo "<<EOF EOF""#, Rule::run)?
+        .as_run().unwrap()
+        .as_shell().unwrap(),
+      &BreakableString::new((4, 20))
+        .add_string((4, 20), "echo \"<<EOF EOF\"")
+    );
+
+    Ok(())
+  }
 }

--- a/src/instructions/run.rs
+++ b/src/instructions/run.rs
@@ -644,6 +644,128 @@ mod tests {
   }
 
   #[test]
+  fn run_heredoc_single_quoted() -> Result<()> {
+    assert_eq!(
+      parse_single(indoc!(r#"RUN cat <<'EOF'
+        hello
+        EOF
+      "#), Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 25),
+        options: vec![],
+        expr: ShellOrExecExpr::ShellWithHeredoc(
+          BreakableString::new((4, 8))
+            .add_string((4, 8), "cat "),
+          Heredoc {
+            span: Span::new(8, 25),
+            content: "<<'EOF'\nhello\nEOF".to_string(),
+          }
+        ),
+      }.into()
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn run_heredoc_double_quoted() -> Result<()> {
+    assert_eq!(
+      parse_single(indoc!(r#"RUN cat <<"EOF"
+        hello
+        EOF
+      "#), Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 25),
+        options: vec![],
+        expr: ShellOrExecExpr::ShellWithHeredoc(
+          BreakableString::new((4, 8))
+            .add_string((4, 8), "cat "),
+          Heredoc {
+            span: Span::new(8, 25),
+            content: "<<\"EOF\"\nhello\nEOF".to_string(),
+          }
+        ),
+      }.into()
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn run_heredoc_dash() -> Result<()> {
+    assert_eq!(
+      parse_single("RUN cat <<-EOF\n\thello\n\tEOF\n", Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 26),
+        options: vec![],
+        expr: ShellOrExecExpr::ShellWithHeredoc(
+          BreakableString::new((4, 8))
+            .add_string((4, 8), "cat "),
+          Heredoc {
+            span: Span::new(8, 26),
+            content: "<<-EOF\n\thello\n\tEOF".to_string(),
+          }
+        ),
+      }.into()
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn run_heredoc_dash_quoted() -> Result<()> {
+    assert_eq!(
+      parse_single("RUN cat <<-'EOF'\n\thello\n\tEOF\n", Rule::run)?,
+      RunInstruction {
+        span: Span::new(0, 28),
+        options: vec![],
+        expr: ShellOrExecExpr::ShellWithHeredoc(
+          BreakableString::new((4, 8))
+            .add_string((4, 8), "cat "),
+          Heredoc {
+            span: Span::new(8, 28),
+            content: "<<-'EOF'\n\thello\n\tEOF".to_string(),
+          }
+        ),
+      }.into()
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn run_heredoc_quoted_preserves_dollar_signs() -> Result<()> {
+    let ins = parse_single(indoc!(r#"RUN cat > /f <<'EOF'
+      echo $VAR ${BRACE}
+      EOF
+    "#), Rule::run)?.into_run().unwrap();
+
+    let (_, heredoc) = ins.expr.as_shell_with_heredoc().unwrap();
+    assert_eq!(heredoc.content, "<<'EOF'\necho $VAR ${BRACE}\nEOF");
+
+    Ok(())
+  }
+
+  #[test]
+  fn run_heredoc_repro_from_bug_report() -> Result<()> {
+    let ins = parse_single(indoc!(r#"RUN cat > /test.conf << 'EOF'
+      server {
+          listen 80;
+      }
+      EOF
+    "#), Rule::run)?.into_run().unwrap();
+
+    let (breakable, heredoc) = ins.expr.as_shell_with_heredoc().unwrap();
+    assert_eq!(breakable.to_string(), "cat > /test.conf ");
+    assert_eq!(
+      heredoc.content,
+      "<< 'EOF'\nserver {\n    listen 80;\n}\nEOF"
+    );
+
+    Ok(())
+  }
+
+  #[test]
   fn run_option_display() -> Result<()> {
     let ins = parse_single(r#"run --security=insecure --mount=type=cache,target=/root echo hi"#, Rule::run)?
       .into_run().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,10 +43,7 @@ mod dockerfile_parser;
 
 pub use image::*;
 pub use error::*;
-pub use parser::*;
-pub use instructions::*;
 pub use splicer::*;
-pub use stage::*;
 pub use util::*;
 pub use crate::dockerfile_parser::*;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -283,17 +283,11 @@ pub(crate) fn parse_any_breakable(pair: Pair) -> Result<BreakableString> {
 
 pub struct Heredoc {
   pub span: Span,
-  // pub operator: String,
-  // pub delimiter: String,
   pub commands: Vec<String>,
 }
 
-// impl 
-
 pub(crate) fn parse_heredoc(record: Pair) -> Result<Heredoc> {
   let span = Span::from_pair(&record);
-  // let mut operator = None;
-  // let mut delimiter = None;
   let mut commands = Vec::new();
 
   for field in record.into_inner() {
@@ -310,8 +304,6 @@ pub(crate) fn parse_heredoc(record: Pair) -> Result<Heredoc> {
 
   Ok(Heredoc {
     span,
-    // operator: operator.ok_or_else(|| Error::GenericParseError { message: "heredoc operator is required".into() })?,
-    // delimiter: delimiter.ok_or_else(|| Error::GenericParseError { message: "heredoc delimiter is required".into() })?,
     commands,
   })
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -58,6 +58,7 @@ pub(crate) fn clean_escaped_breaks(s: &str) -> String {
 pub enum ShellOrExecExpr {
   Shell(BreakableString),
   Exec(StringArray),
+  Heredoc(Heredoc),
 }
 
 impl ShellOrExecExpr {
@@ -274,5 +275,43 @@ pub(crate) fn parse_any_breakable(pair: Pair) -> Result<BreakableString> {
   Ok(BreakableString {
     span: (&pair).into(),
     components: parse_any_breakable_inner(pair)?,
+  })
+}
+
+/// A heredoc expression
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
+
+pub struct Heredoc {
+  pub span: Span,
+  // pub operator: String,
+  // pub delimiter: String,
+  pub commands: Vec<String>,
+}
+
+// impl 
+
+pub(crate) fn parse_heredoc(record: Pair) -> Result<Heredoc> {
+  let span = Span::from_pair(&record);
+  // let mut operator = None;
+  // let mut delimiter = None;
+  let mut commands = Vec::new();
+
+  for field in record.into_inner() {
+    match field.as_rule() {
+      Rule::heredoc_body => {
+        let content = field.as_str().to_string();
+        commands = content.lines().map(String::from).collect();
+      }
+      _ => return {
+        Err(unexpected_token(field))
+      }
+    }
+  }
+
+  Ok(Heredoc {
+    span,
+    // operator: operator.ok_or_else(|| Error::GenericParseError { message: "heredoc operator is required".into() })?,
+    // delimiter: delimiter.ok_or_else(|| Error::GenericParseError { message: "heredoc delimiter is required".into() })?,
+    commands,
   })
 }

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -392,51 +392,6 @@ fn parse_from_sha256_digest_and_tag() -> Result<(), dockerfile_parser::Error> {
 
     assert_eq!(dockerfile.instructions.len(), 1);
 
-    dbg!(dockerfile.instructions[0].as_from());
-
-    assert_eq!(
-        dockerfile.instructions[0].as_from(),
-        Some(&FromInstruction {
-            index: 0,
-            span: (5, 102).into(),
-            image: SpannedString {
-                span: Span { start: 10, end: 95 },
-                content:
-                    "alpine:latest@sha256:074d3636ebda6dd446d0d00304c4454f468237fdacf08fb0eeac90bdbfa1bac7"
-                        .into(),
-            },
-            image_parsed: ImageRef {
-                registry: None,
-                image: "alpine".into(),
-                tag: Some("latest".into()),
-                hash: Some(
-                    "sha256:074d3636ebda6dd446d0d00304c4454f468237fdacf08fb0eeac90bdbfa1bac7"
-                        .into()
-                ),
-            },
-            alias: Some(SpannedString {
-                span: Span { start: 99, end: 102 },
-                content: "foo".into(),
-            }),
-            flags: vec![],
-        })
-    );
-
-    Ok(())
-}
-
-#[test]
-fn parse_from_sha256_digest_and_tag_degen() -> Result<(), dockerfile_parser::Error> {
-    let dockerfile = Dockerfile::parse(
-        r#"
-    FROM alpine@sha256:074d3636ebda6dd446d0d00304c4454f468237fdacf08fb0eeac90bdbfa1bac7 as foo
-  "#,
-    )?;
-
-    assert_eq!(dockerfile.instructions.len(), 1);
-
-    dbg!(dockerfile.instructions[0].as_from());
-
     assert_eq!(
         dockerfile.instructions[0].as_from(),
         Some(&FromInstruction {

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -380,3 +380,90 @@ fn parse_from_sha256_digest() -> Result<(), dockerfile_parser::Error> {
 
     Ok(())
 }
+
+
+#[test]
+fn parse_from_sha256_digest_and_tag() -> Result<(), dockerfile_parser::Error> {
+    let dockerfile = Dockerfile::parse(
+        r#"
+    FROM alpine:latest@sha256:074d3636ebda6dd446d0d00304c4454f468237fdacf08fb0eeac90bdbfa1bac7 as foo
+  "#,
+    )?;
+
+    assert_eq!(dockerfile.instructions.len(), 1);
+
+    dbg!(dockerfile.instructions[0].as_from());
+
+    assert_eq!(
+        dockerfile.instructions[0].as_from(),
+        Some(&FromInstruction {
+            index: 0,
+            span: (5, 102).into(),
+            image: SpannedString {
+                span: Span { start: 10, end: 95 },
+                content:
+                    "alpine:latest@sha256:074d3636ebda6dd446d0d00304c4454f468237fdacf08fb0eeac90bdbfa1bac7"
+                        .into(),
+            },
+            image_parsed: ImageRef {
+                registry: None,
+                image: "alpine".into(),
+                tag: Some("latest".into()),
+                hash: Some(
+                    "sha256:074d3636ebda6dd446d0d00304c4454f468237fdacf08fb0eeac90bdbfa1bac7"
+                        .into()
+                ),
+            },
+            alias: Some(SpannedString {
+                span: Span { start: 99, end: 102 },
+                content: "foo".into(),
+            }),
+            flags: vec![],
+        })
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parse_from_sha256_digest_and_tag_degen() -> Result<(), dockerfile_parser::Error> {
+    let dockerfile = Dockerfile::parse(
+        r#"
+    FROM alpine@sha256:074d3636ebda6dd446d0d00304c4454f468237fdacf08fb0eeac90bdbfa1bac7 as foo
+  "#,
+    )?;
+
+    assert_eq!(dockerfile.instructions.len(), 1);
+
+    dbg!(dockerfile.instructions[0].as_from());
+
+    assert_eq!(
+        dockerfile.instructions[0].as_from(),
+        Some(&FromInstruction {
+            index: 0,
+            span: (5, 102).into(),
+            image: SpannedString {
+                span: Span { start: 10, end: 95 },
+                content:
+                    "alpine:latest@sha256:074d3636ebda6dd446d0d00304c4454f468237fdacf08fb0eeac90bdbfa1bac7"
+                        .into(),
+            },
+            image_parsed: ImageRef {
+                registry: None,
+                image: "alpine".into(),
+                tag: Some("latest".into()),
+                hash: Some(
+                    "sha256:074d3636ebda6dd446d0d00304c4454f468237fdacf08fb0eeac90bdbfa1bac7"
+                        .into()
+                ),
+            },
+            alias: Some(SpannedString {
+                span: Span { start: 99, end: 102 },
+                content: "foo".into(),
+            }),
+            flags: vec![],
+        })
+    );
+
+    Ok(())
+}

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -422,3 +422,35 @@ fn parse_from_sha256_digest_and_tag() -> Result<(), dockerfile_parser::Error> {
 
     Ok(())
 }
+
+#[test]
+fn parse_run_with_quoted_shell_heredoc() -> Result<(), dockerfile_parser::Error> {
+    let dockerfile = Dockerfile::parse(indoc!(
+        r#"
+            FROM ubuntu:24.04
+            RUN cat > /test.conf << 'EOF'
+            server {
+                listen 80;
+            }
+            EOF
+        "#
+    ))?;
+
+    assert_eq!(dockerfile.instructions.len(), 2);
+
+    let run = match &dockerfile.instructions[1] {
+        Instruction::Run(r) => r,
+        other => panic!("expected RUN, got {:?}", other),
+    };
+
+    let (breakable, heredoc) = run.expr.as_shell_with_heredoc().expect(
+        "shell heredoc with quoted delimiter should parse as ShellWithHeredoc, not fragment",
+    );
+    assert_eq!(breakable.to_string(), "cat > /test.conf ");
+    assert_eq!(
+        heredoc.content,
+        "<< 'EOF'\nserver {\n    listen 80;\n}\nEOF"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes a parser bug that caused real-world Dockerfiles using shell heredocs in `RUN` to fragment into broken instruction streams, surfacing downstream as opaque "Image build failed" errors.

The previous grammar only recognized bare alphanumeric heredoc delimiters, so the following common patterns all failed to parse:

| Source pattern              | Before      | After              |
|---                          |---          |---                 |
| `RUN cat > /f <<'EOF'`      | parse error | parses ✅          |
| `RUN cat > /f <<"EOF"`      | parse error | parses ✅          |
| `RUN cat > /f <<-EOF`       | parse error | parses ✅          |
| `RUN cat > /f <<-'EOF'`     | parse error | parses ✅          |
| `RUN cat > /f << EOF`       | parses      | parses (unchanged) |
| `RUN <<EOF`                 | parses      | parses (unchanged) |

When the heredoc start failed to match, `any_breakable` consumed only the first line and the body lines were re-entered as separate `meta_step`s — producing either a parse error or a fragmented Dockerfile of garbage `MiscInstruction`s.

The dominant real-world pattern for writing config files inline (nginx, systemd unit files, scripts) uses `<< 'EOF'` / `<< "EOF"` to suppress shell variable expansion in the body — which is precisely the form that didn't parse.

## Changes

Grammar-only, additive changes in `src/dockerfile_parser.pest`:

- `heredoc_op` accepts an optional trailing `-` (the `<<-` variant).
- `heredoc_delim` accepts the bare name optionally wrapped in matching `'…'` or `"…"`. The `PUSH`ed token is always the unquoted name, so `<<'EOF'` is closed by `EOF` (matching bash semantics).
- `heredoc_terminator` tolerates leading tabs to support `<<-` body indentation.

No Rust changes were needed: `parse_heredoc` stores `record.as_str()` verbatim into `Heredoc::content`, which round-trips the original (quoted or dashed) source faithfully back to BuildKit.

## Test plan

- [x] All 83 existing tests still pass (lib + integration + doc)
- [x] 6 new unit tests in `src/instructions/run.rs` covering single-quoted, double-quoted, dash, dash+quoted, `$VAR` non-expansion, and the exact nginx-config repro from the bug report
- [x] 1 new integration test in `tests/parsing.rs` confirming a full Dockerfile with `RUN cat > /test.conf << 'EOF' …` produces exactly two instructions, not a fragmented mess
- [x] Re-ran an empirical 6-case probe — all heredoc forms above produce a single `RunInstruction` with the expected `ShellWithHeredoc` shape and span offsets

## Notes

- Addresses **Bug 1** from the Modal failure report (186 of 208 task failures, ~17.4% of builds).
- **Bug 2** (`COPY <<'EOF'`) shares these grammar rules and is incidentally improved, but `copy_heredoc` has its own gaps — follow-up PR.
